### PR TITLE
Add /metrics endpoint with PDF generation histograms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ src/
     health/
       handler.ts         # GET /health → { status: "ok" }
       index.ts           # Registers GET /health
+    metrics/
+      index.ts           # Registers GET /metrics; injects MetricsService
     pdf/
       schema.ts          # Zod schema; z.toJSONSchema() with $schema stripped for AJV compat
       handler.ts         # generate PDF → stream bytes or upload to S3 + return presigned URL
@@ -40,6 +42,7 @@ src/
   services/
     pdf/PdfService.ts          # Puppeteer browser lifecycle + PDF generation
     storage/StorageService.ts  # S3 upload (s3 client) + presigned URL (s3Public client)
+    metrics/MetricsService.ts  # In-memory histograms + counter; serialises to Prometheus text
   types/
     index.ts                   # GenerateRequest, PaperOptions, PdfOptions, GenerateResponse
     aws-lambda-fastify.d.ts    # Ambient declaration for aws-lambda-fastify (no types shipped)
@@ -59,6 +62,22 @@ Returns service liveness. Also responds to `HEAD /health`.
 Use for load balancer health checks or Lambda function URL probes. No auth required.
 
 **Files:** `src/routes/health/index.ts`, `src/routes/health/handler.ts`
+
+---
+
+### GET /metrics
+
+Returns Prometheus text-format metrics (`text/plain; version=0.0.4`).
+
+| Metric | Type | Buckets |
+|---|---|---|
+| `pdf_generation_duration_ms` | histogram | 100, 250, 500, 1000, 2500, 5000, 10000 ms |
+| `pdf_size_bytes` | histogram | 10 KB, 50 KB, 100 KB, 500 KB, 1 MB, 5 MB, 10 MB |
+| `pdf_generation_requests_total` | counter | labels: `status="success"`, `status="error"` |
+
+Metrics are in-memory (reset on restart). `MetricsService` is instantiated in `server.ts`, passed to the PDF route handler (which calls `recordSuccess`/`recordError`), and injected into the metrics route.
+
+**Files:** `src/routes/metrics/index.ts`, `src/services/metrics/MetricsService.ts`
 
 ---
 
@@ -142,7 +161,7 @@ npm run build
 ## Testing Strategy
 
 - **Unit tests**: `PdfService` and `StorageService` are unit-tested with mocked dependencies (no real browser, no real S3). Vitest v4 requires constructor mocks to use `class` syntax — not arrow function implementations.
-- **Integration tests**: `test/integration/generate.test.ts` uses `app.inject()` — full Fastify route pipeline, no real browser or S3.
+- **Integration tests**: `test/integration/generate.test.ts` and `test/integration/metrics.test.ts` use `app.inject()` — full Fastify route pipeline, no real browser or S3. The metrics test fires a `/pdf/generate` request and then asserts that counters and bucket values in `/metrics` reflect it.
 - **No Chromium in CI**: Tests run with mocked Puppeteer, so CI doesn't need to install Chromium.
 
 ## Extension Plans
@@ -156,7 +175,7 @@ Planned features are documented in `.plans/`:
 | `url-rendering.md` | Render a URL instead of raw HTML (includes SSRF notes) |
 | `async-webhook.md` | `202 Accepted` + webhook callback for slow jobs |
 | `api-key-auth.md` | `X-Api-Key` header auth with timing-safe comparison |
-| `observability.md` | `/metrics`, PDF generation histograms (`/health` already implemented) |
+| `observability.md` | `/metrics` + PDF generation histograms — **implemented** |
 | `additional-routes.md` | `GET /pdf/:id`, `DELETE /pdf/:id`, `POST /pdf/merge` |
 | `queue-based-scaling.md` | SQS / BullMQ decoupled worker tier |
 | `node-server-deployment.md` | ECS Fargate / Fly.io plain Node server deployment |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,38 @@ Use this as the target for load balancer health checks or Lambda function URL pr
 
 ---
 
+### `GET /metrics`
+
+Returns Prometheus-format metrics for the PDF generation service.
+
+**Response**
+
+```
+Content-Type: text/plain; version=0.0.4; charset=utf-8
+
+# HELP pdf_generation_duration_ms Duration of PDF generation in milliseconds
+# TYPE pdf_generation_duration_ms histogram
+pdf_generation_duration_ms_bucket{le="100"} 0
+...
+# HELP pdf_size_bytes Size of generated PDF in bytes
+# TYPE pdf_size_bytes histogram
+...
+# HELP pdf_generation_requests_total Total number of PDF generation requests
+# TYPE pdf_generation_requests_total counter
+pdf_generation_requests_total{status="success"} 42
+pdf_generation_requests_total{status="error"} 1
+```
+
+| Metric | Type | Description |
+|---|---|---|
+| `pdf_generation_duration_ms` | histogram | PDF generation wall-clock time; buckets at 100, 250, 500, 1000, 2500, 5000, 10000 ms |
+| `pdf_size_bytes` | histogram | Generated PDF file size; buckets at 10 KB, 50 KB, 100 KB, 500 KB, 1 MB, 5 MB, 10 MB |
+| `pdf_generation_requests_total` | counter | Request count labelled by `status="success"` or `status="error"` |
+
+Metrics are in-memory and reset on process restart. Scrape with Prometheus or any compatible collector.
+
+---
+
 ### `POST /pdf/generate`
 
 **Request**
@@ -156,6 +188,8 @@ src/
     health/
       handler.ts         # GET /health → { status: "ok" }
       index.ts           # Route registration (GET /health)
+    metrics/
+      index.ts           # Route registration (GET /metrics)
     pdf/
       schema.ts          # Zod schema → JSON Schema for AJV validation
       handler.ts         # Orchestration: generate PDF → stream or upload to S3
@@ -163,12 +197,14 @@ src/
   services/
     pdf/PdfService.ts          # Puppeteer browser lifecycle + PDF generation
     storage/StorageService.ts  # S3 upload (s3) + presigned URL (s3Public)
+    metrics/MetricsService.ts  # In-memory Prometheus metrics (histograms + counters)
   types/
     index.ts                   # Shared TypeScript interfaces
     aws-lambda-fastify.d.ts    # Ambient type declaration for aws-lambda-fastify
 
 test/integration/
   generate.test.ts       # Full route tests via app.inject() — no real browser
+  metrics.test.ts        # GET /metrics — verifies histogram/counter output after a generation
 ```
 
 ## Stack

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "pdf-microservice",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.600.0",
         "@aws-sdk/s3-request-presigner": "^3.600.0",
@@ -975,6 +976,43 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {

--- a/src/routes/metrics/index.ts
+++ b/src/routes/metrics/index.ts
@@ -1,0 +1,17 @@
+import type { FastifyPluginAsync } from 'fastify';
+import type { MetricsService } from '../../services/metrics/MetricsService.js';
+
+interface MetricsRouteOptions {
+  metricsService: MetricsService;
+}
+
+export const metricsRoutes: FastifyPluginAsync<MetricsRouteOptions> = async (
+  fastify,
+  { metricsService },
+) => {
+  fastify.get('/metrics', async (_request, reply) => {
+    return reply
+      .header('Content-Type', 'text/plain; version=0.0.4; charset=utf-8')
+      .send(metricsService.format());
+  });
+};

--- a/src/routes/pdf/handler.ts
+++ b/src/routes/pdf/handler.ts
@@ -2,10 +2,12 @@ import type { FastifyReply, FastifyRequest } from 'fastify';
 import type { GenerateRequestInput } from './schema.js';
 import type { PdfService } from '../../services/pdf/PdfService.js';
 import type { StorageService } from '../../services/storage/StorageService.js';
+import type { MetricsService } from '../../services/metrics/MetricsService.js';
 
 export function createGenerateHandler(
   pdfService: PdfService,
   storageService: StorageService,
+  metricsService: MetricsService,
 ) {
   return async function generateHandler(
     request: FastifyRequest<{ Body: GenerateRequestInput }>,
@@ -13,7 +15,15 @@ export function createGenerateHandler(
   ) {
     const { html, paper, options, stream } = request.body;
 
-    const pdfBuffer = await pdfService.generate(html, paper, options);
+    const start = Date.now();
+    let pdfBuffer: Buffer;
+    try {
+      pdfBuffer = await pdfService.generate(html, paper, options);
+    } catch (err) {
+      metricsService.recordError();
+      throw err;
+    }
+    metricsService.recordSuccess(Date.now() - start, pdfBuffer.length);
 
     if (stream) {
       return reply

--- a/src/routes/pdf/index.ts
+++ b/src/routes/pdf/index.ts
@@ -3,20 +3,22 @@ import { generateRequestJsonSchema } from './schema.js';
 import { createGenerateHandler } from './handler.js';
 import type { PdfService } from '../../services/pdf/PdfService.js';
 import type { StorageService } from '../../services/storage/StorageService.js';
+import type { MetricsService } from '../../services/metrics/MetricsService.js';
 
 interface PdfRouteOptions {
   pdfService: PdfService;
   storageService: StorageService;
+  metricsService: MetricsService;
 }
 
 export const pdfRoutes: FastifyPluginAsync<PdfRouteOptions> = async (
   fastify,
-  { pdfService, storageService },
+  { pdfService, storageService, metricsService },
 ) => {
   fastify.post('/pdf/generate', {
     schema: {
       body: generateRequestJsonSchema,
     },
-    handler: createGenerateHandler(pdfService, storageService),
+    handler: createGenerateHandler(pdfService, storageService, metricsService),
   });
 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,8 +3,10 @@ import { env } from './config/env.js';
 import { s3Plugin } from './plugins/s3.js';
 import { sensiblePlugin } from './plugins/sensible.js';
 import { pdfRoutes } from './routes/pdf/index.js';
+import { metricsRoutes } from './routes/metrics/index.js';
 import { PdfService } from './services/pdf/PdfService.js';
 import { StorageService } from './services/storage/StorageService.js';
+import { MetricsService } from './services/metrics/MetricsService.js';
 
 export async function buildApp() {
   const fastify = Fastify({
@@ -18,13 +20,16 @@ export async function buildApp() {
   });
 
   const pdfService = new PdfService();
+  const metricsService = new MetricsService();
 
   await fastify.register(sensiblePlugin);
   await fastify.register(s3Plugin);
   await fastify.register(pdfRoutes, {
     pdfService,
     storageService: new StorageService(fastify.s3, fastify.s3Public),
+    metricsService,
   });
+  await fastify.register(metricsRoutes, { metricsService });
 
   fastify.addHook('onReady', async () => {
     // Warm up the browser on startup to reduce first-request latency

--- a/src/services/metrics/MetricsService.test.ts
+++ b/src/services/metrics/MetricsService.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MetricsService } from './MetricsService.js';
+
+describe('MetricsService', () => {
+  let metrics: MetricsService;
+
+  beforeEach(() => {
+    metrics = new MetricsService();
+  });
+
+  describe('format() with no observations', () => {
+    it('outputs histogram names and counter names', () => {
+      const output = metrics.format();
+      expect(output).toContain('pdf_generation_duration_ms');
+      expect(output).toContain('pdf_size_bytes');
+      expect(output).toContain('pdf_generation_requests_total');
+    });
+
+    it('outputs zero counts', () => {
+      const output = metrics.format();
+      expect(output).toContain('pdf_generation_duration_ms_count 0');
+      expect(output).toContain('pdf_size_bytes_count 0');
+      expect(output).toContain('pdf_generation_requests_total{status="success"} 0');
+      expect(output).toContain('pdf_generation_requests_total{status="error"} 0');
+    });
+  });
+
+  describe('recordSuccess()', () => {
+    it('increments success counter', () => {
+      metrics.recordSuccess(200, 50000);
+      metrics.recordSuccess(300, 60000);
+      expect(metrics.format()).toContain('pdf_generation_requests_total{status="success"} 2');
+    });
+
+    it('accumulates duration sum and count', () => {
+      metrics.recordSuccess(200, 1000);
+      metrics.recordSuccess(400, 2000);
+      const output = metrics.format();
+      expect(output).toContain('pdf_generation_duration_ms_sum 600');
+      expect(output).toContain('pdf_generation_duration_ms_count 2');
+    });
+
+    it('accumulates size sum and count', () => {
+      metrics.recordSuccess(100, 10000);
+      metrics.recordSuccess(200, 30000);
+      const output = metrics.format();
+      expect(output).toContain('pdf_size_bytes_sum 40000');
+      expect(output).toContain('pdf_size_bytes_count 2');
+    });
+
+    it('places value in correct duration buckets (cumulative)', () => {
+      // 300ms falls into buckets >=300: 500, 1000, 2500, 5000, 10000
+      metrics.recordSuccess(300, 1000);
+      const output = metrics.format();
+      expect(output).toContain('pdf_generation_duration_ms_bucket{le="100"} 0');
+      expect(output).toContain('pdf_generation_duration_ms_bucket{le="250"} 0');
+      expect(output).toContain('pdf_generation_duration_ms_bucket{le="500"} 1');
+      expect(output).toContain('pdf_generation_duration_ms_bucket{le="1000"} 1');
+      expect(output).toContain('pdf_generation_duration_ms_bucket{le="+Inf"} 1');
+    });
+
+    it('places value in correct size buckets (cumulative)', () => {
+      // 75000 bytes falls into buckets >=75000: 102400, 512000, 1048576, 5242880, 10485760
+      metrics.recordSuccess(100, 75000);
+      const output = metrics.format();
+      expect(output).toContain('pdf_size_bytes_bucket{le="10240"} 0');
+      expect(output).toContain('pdf_size_bytes_bucket{le="51200"} 0');
+      expect(output).toContain('pdf_size_bytes_bucket{le="102400"} 1');
+      expect(output).toContain('pdf_size_bytes_bucket{le="+Inf"} 1');
+    });
+  });
+
+  describe('recordError()', () => {
+    it('increments error counter', () => {
+      metrics.recordError();
+      metrics.recordError();
+      expect(metrics.format()).toContain('pdf_generation_requests_total{status="error"} 2');
+    });
+
+    it('does not affect histogram counts', () => {
+      metrics.recordError();
+      const output = metrics.format();
+      expect(output).toContain('pdf_generation_duration_ms_count 0');
+      expect(output).toContain('pdf_size_bytes_count 0');
+    });
+  });
+
+  describe('format() output structure', () => {
+    it('includes HELP and TYPE lines for each metric', () => {
+      const output = metrics.format();
+      expect(output).toContain('# HELP pdf_generation_duration_ms');
+      expect(output).toContain('# TYPE pdf_generation_duration_ms histogram');
+      expect(output).toContain('# HELP pdf_size_bytes');
+      expect(output).toContain('# TYPE pdf_size_bytes histogram');
+      expect(output).toContain('# HELP pdf_generation_requests_total');
+      expect(output).toContain('# TYPE pdf_generation_requests_total counter');
+    });
+
+    it('includes +Inf bucket equal to total count', () => {
+      metrics.recordSuccess(50, 5000);
+      metrics.recordSuccess(9999, 9999999);
+      const output = metrics.format();
+      expect(output).toContain('pdf_generation_duration_ms_bucket{le="+Inf"} 2');
+      expect(output).toContain('pdf_size_bytes_bucket{le="+Inf"} 2');
+    });
+  });
+});

--- a/src/services/metrics/MetricsService.ts
+++ b/src/services/metrics/MetricsService.ts
@@ -1,0 +1,78 @@
+const DURATION_BUCKETS_MS = [100, 250, 500, 1000, 2500, 5000, 10000];
+const SIZE_BUCKETS_BYTES = [10240, 51200, 102400, 512000, 1048576, 5242880, 10485760];
+
+interface Histogram {
+  buckets: Map<number, number>;
+  sum: number;
+  count: number;
+}
+
+function createHistogram(upperBounds: number[]): Histogram {
+  const buckets = new Map<number, number>();
+  for (const bound of upperBounds) {
+    buckets.set(bound, 0);
+  }
+  return { buckets, sum: 0, count: 0 };
+}
+
+function recordValue(histogram: Histogram, value: number): void {
+  histogram.sum += value;
+  histogram.count += 1;
+  for (const [bound, count] of histogram.buckets) {
+    if (value <= bound) {
+      histogram.buckets.set(bound, count + 1);
+    }
+  }
+}
+
+function formatHistogram(name: string, help: string, histogram: Histogram): string {
+  const lines: string[] = [
+    `# HELP ${name} ${help}`,
+    `# TYPE ${name} histogram`,
+  ];
+  for (const [bound, count] of histogram.buckets) {
+    lines.push(`${name}_bucket{le="${bound}"} ${count}`);
+  }
+  lines.push(`${name}_bucket{le="+Inf"} ${histogram.count}`);
+  lines.push(`${name}_sum ${histogram.sum}`);
+  lines.push(`${name}_count ${histogram.count}`);
+  return lines.join('\n');
+}
+
+export class MetricsService {
+  private durationMs = createHistogram(DURATION_BUCKETS_MS);
+  private sizeBytes = createHistogram(SIZE_BUCKETS_BYTES);
+  private successCount = 0;
+  private errorCount = 0;
+
+  recordSuccess(durationMs: number, sizeBytes: number): void {
+    recordValue(this.durationMs, durationMs);
+    recordValue(this.sizeBytes, sizeBytes);
+    this.successCount += 1;
+  }
+
+  recordError(): void {
+    this.errorCount += 1;
+  }
+
+  format(): string {
+    return [
+      formatHistogram(
+        'pdf_generation_duration_ms',
+        'Duration of PDF generation in milliseconds',
+        this.durationMs,
+      ),
+      '',
+      formatHistogram(
+        'pdf_size_bytes',
+        'Size of generated PDF in bytes',
+        this.sizeBytes,
+      ),
+      '',
+      '# HELP pdf_generation_requests_total Total number of PDF generation requests',
+      '# TYPE pdf_generation_requests_total counter',
+      `pdf_generation_requests_total{status="success"} ${this.successCount}`,
+      `pdf_generation_requests_total{status="error"} ${this.errorCount}`,
+    ].join('\n');
+  }
+}

--- a/test/integration/metrics.test.ts
+++ b/test/integration/metrics.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+vi.mock('../../src/config/env.js', () => ({
+  env: {
+    S3_BUCKET: 'test-bucket',
+    AWS_REGION: 'us-east-1',
+    SIGNED_URL_EXPIRY_SECONDS: 3600,
+    LOG_LEVEL: 'error',
+    PORT: 8080,
+  },
+}));
+
+vi.mock('../../src/services/pdf/PdfService.js', () => ({
+  PdfService: class {
+    getBrowser = vi.fn().mockResolvedValue({});
+    generate = vi.fn().mockResolvedValue(Buffer.alloc(12000, '%'));
+    close = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../../src/services/storage/StorageService.js', () => ({
+  StorageService: class {
+    upload = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+  },
+}));
+
+vi.mock('../../src/plugins/s3.js', () => ({
+  s3Plugin: async (fastify: FastifyInstance) => {
+    fastify.decorate('s3', {});
+    fastify.decorate('s3Public', {});
+  },
+}));
+
+describe('GET /metrics', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const { buildApp } = await import('../../src/server.js');
+    app = await buildApp();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns 200 with Prometheus text content type', async () => {
+    const response = await app.inject({ method: 'GET', url: '/metrics' });
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('text/plain');
+  });
+
+  it('returns histogram and counter metric names', async () => {
+    const response = await app.inject({ method: 'GET', url: '/metrics' });
+    const body = response.body;
+    expect(body).toContain('pdf_generation_duration_ms');
+    expect(body).toContain('pdf_size_bytes');
+    expect(body).toContain('pdf_generation_requests_total');
+  });
+
+  it('reflects a successful PDF generation in the metrics', async () => {
+    await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      payload: { html: '<html><body>hello</body></html>' },
+    });
+
+    const response = await app.inject({ method: 'GET', url: '/metrics' });
+    const body = response.body;
+
+    expect(body).toContain('pdf_generation_requests_total{status="success"} 1');
+    expect(body).toContain('pdf_generation_requests_total{status="error"} 0');
+    expect(body).toContain('pdf_generation_duration_ms_count 1');
+    // 12000 bytes falls in the 51200 bucket and above
+    expect(body).toContain('pdf_size_bytes_bucket{le="10240"} 0');
+    expect(body).toContain('pdf_size_bytes_bucket{le="51200"} 1');
+    expect(body).toContain('pdf_size_bytes_count 1');
+  });
+});


### PR DESCRIPTION
Tracks pdf_generation_duration_ms and pdf_size_bytes as Prometheus
histograms, plus pdf_generation_requests_total counter with success/error
labels. MetricsService is wired into the PDF handler and exposed at GET
/metrics in Prometheus text format (version 0.0.4).

https://claude.ai/code/session_01PWxfrXLEuQeH17CfChXeQV