### PR TITLE
Add CSS injection support to PDF generation API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,11 +49,14 @@ src/
 ```json
 {
   "html": "<html>...</html>",
+  "css": "body { font-family: Arial; }",
   "paper": { "size": "A4", "orientation": "portrait" },
   "options": {
     "margin": { "top": "10mm", "right": "10mm", "bottom": "10mm", "left": "10mm" },
     "scale": 1.0,
-    "printBackground": false
+    "printBackground": false,
+    "headerTemplate": "<div style=\"font-size:10px;\">Header</div>",
+    "footerTemplate": "<div style=\"font-size:10px;\">Page <span class=\"pageNumber\"></span></div>"
   },
   "stream": false
 }
@@ -130,14 +133,14 @@ npm run build
 
 Planned features are documented in `.plans/`:
 
-| File | Description |
-|---|---|
-| `headers-footers.md` | HTML header/footer templates on every PDF page |
-| `css-injection.md` | Inject extra CSS before rendering |
-| `url-rendering.md` | Render a URL instead of raw HTML (includes SSRF notes) |
-| `async-webhook.md` | `202 Accepted` + webhook callback for slow jobs |
-| `api-key-auth.md` | `X-Api-Key` header auth with timing-safe comparison |
-| `observability.md` | `/health`, `/metrics`, PDF generation histograms |
-| `additional-routes.md` | `GET /pdf/:id`, `DELETE /pdf/:id`, `POST /pdf/merge` |
-| `queue-based-scaling.md` | SQS / BullMQ decoupled worker tier |
-| `node-server-deployment.md` | ECS Fargate / Fly.io plain Node server deployment |
+| File | Description | Status |
+|---|---|---|
+| `headers-footers.md` | HTML header/footer templates on every PDF page | Implemented |
+| `css-injection.md` | Inject extra CSS before rendering | Implemented |
+| `url-rendering.md` | Render a URL instead of raw HTML (includes SSRF notes) | Planned |
+| `async-webhook.md` | `202 Accepted` + webhook callback for slow jobs | Planned |
+| `api-key-auth.md` | `X-Api-Key` header auth with timing-safe comparison | Planned |
+| `observability.md` | `/health`, `/metrics`, PDF generation histograms | Planned |
+| `additional-routes.md` | `GET /pdf/:id`, `DELETE /pdf/:id`, `POST /pdf/merge` | Planned |
+| `queue-based-scaling.md` | SQS / BullMQ decoupled worker tier | Planned |
+| `node-server-deployment.md` | ECS Fargate / Fly.io plain Node server deployment | Planned |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The Chromium browser is launched once at startup and reused across requests. On 
 ```json
 {
   "html": "<html><body><h1>Hello</h1></body></html>",
+  "css": "body { font-family: Arial, sans-serif; }",
   "paper": {
     "size": "A4",
     "orientation": "portrait"
@@ -38,6 +39,7 @@ The Chromium browser is launched once at startup and reused across requests. On 
 | Field | Type | Required | Description |
 |---|---|---|---|
 | `html` | string | yes | HTML to render |
+| `css` | string | no | Extra CSS injected into the page after the HTML is set |
 | `paper.size` | string | no | `A4`, `A3`, `Letter`, `Legal`, `Tabloid` |
 | `paper.orientation` | string | no | `portrait` or `landscape` |
 | `options.margin` | object | no | `top`, `right`, `bottom`, `left` in CSS units |

--- a/src/routes/pdf/handler.ts
+++ b/src/routes/pdf/handler.ts
@@ -11,9 +11,9 @@ export function createGenerateHandler(
     request: FastifyRequest<{ Body: GenerateRequestInput }>,
     reply: FastifyReply,
   ) {
-    const { html, paper, options, stream } = request.body;
+    const { html, css, paper, options, stream } = request.body;
 
-    const pdfBuffer = await pdfService.generate(html, paper, options);
+    const pdfBuffer = await pdfService.generate(html, css, paper, options);
 
     if (stream) {
       return reply

--- a/src/routes/pdf/schema.ts
+++ b/src/routes/pdf/schema.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 export const generateRequestSchema = z.object({
   html: z.string().min(1, 'html is required'),
+  css: z.string().optional(),
   paper: z
     .object({
       size: z.string().optional(),

--- a/src/services/pdf/PdfService.test.ts
+++ b/src/services/pdf/PdfService.test.ts
@@ -4,8 +4,10 @@ import { PdfService } from './PdfService.js';
 const mockPdf = vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 mock'));
 const mockClose = vi.fn().mockResolvedValue(undefined);
 const mockSetContent = vi.fn().mockResolvedValue(undefined);
+const mockAddStyleTag = vi.fn().mockResolvedValue(undefined);
 const mockNewPage = vi.fn().mockResolvedValue({
   setContent: mockSetContent,
+  addStyleTag: mockAddStyleTag,
   pdf: mockPdf,
   close: mockClose,
 });
@@ -43,14 +45,31 @@ describe('PdfService', () => {
     const result = await pdfService.generate(html);
 
     expect(mockSetContent).toHaveBeenCalledWith(html, { waitUntil: 'networkidle0' });
+    expect(mockAddStyleTag).not.toHaveBeenCalled();
     expect(mockPdf).toHaveBeenCalledOnce();
     expect(result).toBeInstanceOf(Buffer);
+  });
+
+  it('injects CSS via addStyleTag when css is provided', async () => {
+    const html = '<html><body><h1>Hello</h1></body></html>';
+    const css = 'body { font-size: 14px; }';
+
+    await pdfService.generate(html, css);
+
+    expect(mockSetContent).toHaveBeenCalledWith(html, { waitUntil: 'networkidle0' });
+    expect(mockAddStyleTag).toHaveBeenCalledWith({ content: css });
+  });
+
+  it('does not call addStyleTag when css is not provided', async () => {
+    await pdfService.generate('<html></html>');
+
+    expect(mockAddStyleTag).not.toHaveBeenCalled();
   });
 
   it('applies paper size options', async () => {
     const html = '<html><body></body></html>';
 
-    await pdfService.generate(html, { size: 'A4', orientation: 'portrait' });
+    await pdfService.generate(html, undefined, { size: 'A4', orientation: 'portrait' });
 
     const pdfCall = mockPdf.mock.calls[0][0];
     expect(pdfCall).toMatchObject({ width: '210mm', height: '297mm' });
@@ -59,7 +78,7 @@ describe('PdfService', () => {
   it('applies landscape orientation by swapping dimensions', async () => {
     const html = '<html><body></body></html>';
 
-    await pdfService.generate(html, { size: 'A4', orientation: 'landscape' });
+    await pdfService.generate(html, undefined, { size: 'A4', orientation: 'landscape' });
 
     const pdfCall = mockPdf.mock.calls[0][0];
     expect(pdfCall).toMatchObject({ width: '297mm', height: '210mm' });
@@ -70,6 +89,7 @@ describe('PdfService', () => {
 
     await pdfService.generate(
       html,
+      undefined,
       undefined,
       {
         printBackground: true,

--- a/src/services/pdf/PdfService.ts
+++ b/src/services/pdf/PdfService.ts
@@ -31,6 +31,7 @@ export class PdfService {
 
   async generate(
     html: string,
+    css?: string,
     paper?: PaperOptions,
     options?: PdfOptions,
   ): Promise<Buffer> {
@@ -39,6 +40,10 @@ export class PdfService {
 
     try {
       await page.setContent(html, { waitUntil: 'networkidle0' });
+
+      if (css) {
+        await page.addStyleTag({ content: css });
+      }
 
       const hasHeaderFooter = !!(options?.headerTemplate || options?.footerTemplate);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,7 @@ export interface PdfOptions {
 
 export interface GenerateRequest {
   html: string;
+  css?: string;
   paper?: PaperOptions;
   options?: PdfOptions;
   stream?: boolean;

--- a/test/integration/generate.test.ts
+++ b/test/integration/generate.test.ts
@@ -149,6 +149,19 @@ describe('POST /pdf/generate', () => {
     expect(response.statusCode).toBe(200);
   });
 
+  it('accepts a css field and returns 200', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      payload: {
+        html: '<html><body><h1>Test</h1></body></html>',
+        css: 'body { font-size: 14px; color: #333; }',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
   it('accepts headerTemplate without footerTemplate', async () => {
     const response = await app.inject({
       method: 'POST',


### PR DESCRIPTION
Adds an optional top-level `css` field to the POST /pdf/generate request.
When provided, the CSS is injected into the Puppeteer page via
`page.addStyleTag()` after the HTML is set, allowing callers to supply
styles separately from the HTML content.

https://claude.ai/code/session_015n9HHBWsmqZptBx6e9GczT