### PR TITLE
feat: add GET /pdf/:id, DELETE /pdf/:id, POST /pdf/merge routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,8 @@ Runs as both a Docker container (local dev) and an AWS Lambda container image (p
 | Layer | Package | Version |
 |---|---|---|
 | Framework | Fastify | 5.x |
-| PDF | puppeteer-core + @sparticuz/chromium | 24.x / 143.x |
+| PDF rendering | puppeteer-core + @sparticuz/chromium | 24.x / 143.x |
+| PDF merging | pdf-lib | 1.x |
 | Validation | Zod | 4.x |
 | Storage | @aws-sdk/client-s3 | 3.x |
 | Logging | Pino (Fastify built-in) + pino-pretty | — |
@@ -109,6 +110,61 @@ Metrics are in-memory (reset on restart). `MetricsService` is instantiated in `s
 - `Content-Type: application/pdf`
 - Binary PDF bytes
 
+---
+
+### GET /pdf/:id
+
+Returns a fresh presigned URL for a previously generated PDF. The id path parameter must be a UUID.
+
+**Response:**
+```json
+{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+```
+
+S3 key format: `pdfs/{id}.pdf`. TTL governed by `SIGNED_URL_EXPIRY_SECONDS`.
+
+**Files:** `src/routes/pdf/index.ts`, `src/routes/pdf/handler.ts` (`createGetHandler`), `src/services/storage/StorageService.ts` (`getUrl`)
+
+---
+
+### DELETE /pdf/:id
+
+Permanently deletes a PDF from S3. The id path parameter must be a UUID.
+
+**Response:** `HTTP 204 No Content`
+
+**Files:** `src/routes/pdf/index.ts`, `src/routes/pdf/handler.ts` (`createDeleteHandler`), `src/services/storage/StorageService.ts` (`delete`)
+
+---
+
+### POST /pdf/merge
+
+Downloads two or more existing PDFs by their IDs, merges them in page order using `pdf-lib`, and either streams the result or uploads it to S3.
+
+**Request body:**
+```json
+{
+  "ids": ["550e8400-e29b-41d4-a716-446655440000", "6ba7b810-9dad-11d1-80b4-00c04fd430c8"],
+  "stream": false
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ids` | UUID[] | yes | Ordered list of PDF IDs (minimum 2) |
+| `stream` | boolean | no | `true` = binary, `false` = S3 URL (default) |
+
+**Response (`stream: false`):**
+```json
+{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+```
+
+**Response (`stream: true`):** `Content-Type: application/pdf`, `Content-Disposition: attachment; filename="merged.pdf"`, binary PDF bytes.
+
+All source PDFs are fetched in parallel (`Promise.all`). Pages are copied in the order of the `ids` array.
+
+**Files:** `src/routes/pdf/index.ts`, `src/routes/pdf/handler.ts` (`createMergeHandler`), `src/services/storage/StorageService.ts` (`download`, `upload`)
+
 ## Key Decisions
 
 1. **Browser reuse**: `PdfService` holds the `Browser` instance at class level. `lambda.ts` calls `buildApp()` outside the handler via a module-level promise — Lambda freezes the process between invocations, so the browser survives and is reused on warm calls.
@@ -179,6 +235,6 @@ Planned features are documented in `.plans/`:
 | `async-webhook.md` | `202 Accepted` + webhook callback for slow jobs | Planned |
 | `api-key-auth.md` | `X-Api-Key` header auth with timing-safe comparison | Planned |
 | `observability.md` | `/health`, `/metrics`, PDF generation histograms | Implemented |
-| `additional-routes.md` | `GET /pdf/:id`, `DELETE /pdf/:id`, `POST /pdf/merge` | Planned |
+| `additional-routes.md` | `GET /pdf/:id`, `DELETE /pdf/:id`, `POST /pdf/merge` | Implemented |
 | `queue-based-scaling.md` | SQS / BullMQ decoupled worker tier | Planned |
 | `node-server-deployment.md` | ECS Fargate / Fly.io plain Node server deployment | Planned |

--- a/README.md
+++ b/README.md
@@ -109,6 +109,74 @@ Content-Disposition: attachment; filename="document.pdf"
 <binary PDF bytes>
 ```
 
+---
+
+### `GET /pdf/:id`
+
+Returns a fresh presigned `GetObject` URL for a previously generated PDF.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | UUID (path) | The UUID returned at generation time |
+
+**Response**
+
+```json
+{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+```
+
+The TTL of the returned URL is controlled by `SIGNED_URL_EXPIRY_SECONDS` (default 1 h). The PDF is stored under the key `pdfs/{id}.pdf`.
+
+---
+
+### `DELETE /pdf/:id`
+
+Permanently deletes a PDF from S3.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `id` | UUID (path) | The UUID of the PDF to delete |
+
+**Response**
+
+```
+HTTP 204 No Content
+```
+
+---
+
+### `POST /pdf/merge`
+
+Merges two or more existing PDFs (by their IDs) into a single document in page order.
+
+**Request**
+
+```json
+{
+  "ids": ["550e8400-e29b-41d4-a716-446655440000", "6ba7b810-9dad-11d1-80b4-00c04fd430c8"],
+  "stream": false
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `ids` | UUID[] | yes | Ordered list of PDF IDs to merge (minimum 2) |
+| `stream` | boolean | no | `true` = binary response, `false` = S3 URL (default) |
+
+**Response — S3 URL (`stream: false`)**
+
+```json
+{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+```
+
+**Response — binary stream (`stream: true`)**
+
+```
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="merged.pdf"
+<binary PDF bytes>
+```
+
 ## Local development
 
 Prerequisites: Docker and Docker Compose.
@@ -214,7 +282,8 @@ test/integration/
 | Layer | Package | Version |
 |---|---|---|
 | Framework | Fastify | 5.x |
-| PDF | puppeteer-core + @sparticuz/chromium | 24.x / 143.x |
+| PDF rendering | puppeteer-core + @sparticuz/chromium | 24.x / 143.x |
+| PDF merging | pdf-lib | 1.x |
 | Validation | Zod | 4.x |
 | Storage | @aws-sdk/client-s3 | 3.x |
 | Logging | Pino (Fastify built-in) + pino-pretty | — |

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "aws-lambda-fastify": "^2.2.0",
         "fastify": "^5.8.4",
         "fastify-plugin": "^5.1.0",
+        "pdf-lib": "^1.17.1",
         "pino-pretty": "^13.1.3",
         "puppeteer-core": "^24.40.0",
         "zod": "^4.3.6"
@@ -1859,6 +1860,24 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pinojs/redact": {
@@ -5326,6 +5345,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5367,6 +5392,24 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/pend": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -13,27 +13,28 @@
     "test:cov": "vitest run --coverage"
   },
   "dependencies": {
-    "fastify": "^5.8.4",
-    "@fastify/sensible": "^6.0.4",
-    "aws-lambda-fastify": "^2.2.0",
-    "fastify-plugin": "^5.1.0",
-    "puppeteer-core": "^24.40.0",
-    "@sparticuz/chromium": "^143.0.4",
-    "zod": "^4.3.6",
     "@aws-sdk/client-s3": "^3.600.0",
     "@aws-sdk/s3-request-presigner": "^3.600.0",
-    "pino-pretty": "^13.1.3"
+    "@fastify/sensible": "^6.0.4",
+    "@sparticuz/chromium": "^143.0.4",
+    "aws-lambda-fastify": "^2.2.0",
+    "fastify": "^5.8.4",
+    "fastify-plugin": "^5.1.0",
+    "pdf-lib": "^1.17.1",
+    "pino-pretty": "^13.1.3",
+    "puppeteer-core": "^24.40.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
-    "typescript": "^5.9.3",
-    "@types/node": "^24.0.0",
+    "@eslint/js": "^10.0.1",
     "@types/aws-lambda": "^8.10.0",
-    "vitest": "^4.1.2",
+    "@types/node": "^24.0.0",
     "@vitest/coverage-v8": "^4.1.2",
     "esbuild": "^0.27.4",
     "eslint": "^10.1.0",
-    "@eslint/js": "^10.0.1",
+    "tsx": "^4.0.0",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.0.0",
-    "tsx": "^4.0.0"
+    "vitest": "^4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint src test",
     "test": "vitest run",
-    "test:cov": "vitest run --coverage"
+    "test:cov": "vitest run --coverage",
+    "smoke": "bash scripts/smoke-test.sh"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.600.0",

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# smoke-test.sh — end-to-end test of all PDF microservice routes
+# Usage: ./scripts/smoke-test.sh [BASE_URL]
+# Default BASE_URL: http://localhost:8080
+
+set -euo pipefail
+
+BASE="${1:-http://localhost:8080}"
+PASS=0
+FAIL=0
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+green() { printf '\033[32m✓ %s\033[0m\n' "$*"; }
+red()   { printf '\033[31m✗ %s\033[0m\n' "$*"; }
+
+ok() {
+  green "$1"
+  PASS=$((PASS + 1))
+}
+
+fail() {
+  red "$1"
+  FAIL=$((FAIL + 1))
+}
+
+# assert_eq LABEL expected actual
+assert_eq() {
+  if [ "$2" = "$3" ]; then
+    ok "$1 (got: $3)"
+  else
+    fail "$1 (expected: $2, got: $3)"
+  fi
+}
+
+# assert_contains LABEL needle haystack
+assert_contains() {
+  if echo "$3" | grep -qF "$2"; then
+    ok "$1"
+  else
+    fail "$1 (expected to contain: $2)"
+    echo "    Response: $3"
+  fi
+}
+
+# extract the UUID from a presigned S3/MinIO URL
+# key format: pdfs/{uuid}.pdf
+extract_id() {
+  echo "$1" | sed 's|.*pdfs/\([^.]*\)\.pdf.*|\1|'
+}
+
+echo "=== PDF Microservice Smoke Test ==="
+echo "Base URL: $BASE"
+echo ""
+
+# ── GET /health ───────────────────────────────────────────────────────────────
+
+echo "--- GET /health ---"
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/health")
+assert_eq "HTTP 200" "200" "$STATUS"
+
+BODY=$(curl -s "$BASE/health")
+assert_contains "body contains status:ok" '"status":"ok"' "$BODY"
+
+echo ""
+
+# ── GET /metrics (baseline) ───────────────────────────────────────────────────
+
+echo "--- GET /metrics ---"
+STATUS=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/metrics")
+assert_eq "HTTP 200" "200" "$STATUS"
+
+METRICS=$(curl -s "$BASE/metrics")
+assert_contains "duration histogram present" "pdf_generation_duration_ms_bucket" "$METRICS"
+assert_contains "size histogram present"     "pdf_size_bytes_bucket"             "$METRICS"
+assert_contains "requests counter present"   "pdf_generation_requests_total"     "$METRICS"
+
+echo ""
+
+# ── POST /pdf/generate → S3 URL ───────────────────────────────────────────────
+
+echo "--- POST /pdf/generate (stream: false) ---"
+RESP=$(curl -s -X POST "$BASE/pdf/generate" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "html": "<html><body><h1>Smoke Test Page 1</h1></body></html>",
+    "css": "body { font-family: Arial, sans-serif; }",
+    "paper": { "size": "A4", "orientation": "portrait" },
+    "options": { "margin": { "top": "15mm", "bottom": "15mm" } }
+  }')
+
+STATUS_CODE=$(echo "$RESP" | grep -o '"statusCode":[0-9]*' | grep -o '[0-9]*')
+assert_eq "statusCode 200" "200" "$STATUS_CODE"
+assert_contains "response contains url" '"url"' "$RESP"
+
+URL1=$(echo "$RESP" | sed 's/.*"url":"\([^"]*\)".*/\1/')
+ID1=$(extract_id "$URL1")
+echo "    ID 1: $ID1"
+
+echo ""
+
+# ── POST /pdf/generate (stream: true) ────────────────────────────────────────
+
+echo "--- POST /pdf/generate (stream: true) ---"
+TMP_PDF=$(mktemp /tmp/smoke-test-XXXXXX.pdf)
+HTTP_CODE=$(curl -s -X POST "$BASE/pdf/generate" \
+  -H "Content-Type: application/json" \
+  -d '{"html": "<html><body><h1>Smoke Test Page 2</h1></body></html>", "stream": true}' \
+  -o "$TMP_PDF" -w "%{http_code}")
+
+assert_eq "HTTP 200" "200" "$HTTP_CODE"
+
+# PDF files start with %PDF
+MAGIC=$(head -c 4 "$TMP_PDF" 2>/dev/null || true)
+if [ "$MAGIC" = "%PDF" ]; then
+  ok "response is a valid PDF"
+else
+  fail "response is not a valid PDF (magic bytes: $MAGIC)"
+fi
+rm -f "$TMP_PDF"
+
+echo ""
+
+# Generate a second PDF for merge/delete tests
+echo "--- POST /pdf/generate (second PDF for merge) ---"
+RESP2=$(curl -s -X POST "$BASE/pdf/generate" \
+  -H "Content-Type: application/json" \
+  -d '{"html": "<html><body><h1>Smoke Test Page 2</h1></body></html>"}')
+URL2=$(echo "$RESP2" | sed 's/.*"url":"\([^"]*\)".*/\1/')
+ID2=$(extract_id "$URL2")
+assert_contains "second generate ok" '"statusCode":200' "$RESP2"
+echo "    ID 2: $ID2"
+
+echo ""
+
+# ── GET /pdf/:id ──────────────────────────────────────────────────────────────
+
+echo "--- GET /pdf/:id ---"
+RESP=$(curl -s "$BASE/pdf/$ID1")
+STATUS_CODE=$(echo "$RESP" | grep -o '"statusCode":[0-9]*' | grep -o '[0-9]*')
+assert_eq "statusCode 200" "200" "$STATUS_CODE"
+assert_contains "response contains url" '"url"' "$RESP"
+
+echo ""
+
+# ── GET /pdf/:id with invalid UUID ───────────────────────────────────────────
+
+echo "--- GET /pdf/:id (invalid UUID → 400) ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/pdf/not-a-uuid")
+assert_eq "HTTP 400" "400" "$HTTP_CODE"
+
+echo ""
+
+# ── POST /pdf/merge → S3 URL ─────────────────────────────────────────────────
+
+echo "--- POST /pdf/merge (stream: false) ---"
+RESP=$(curl -s -X POST "$BASE/pdf/merge" \
+  -H "Content-Type: application/json" \
+  -d "{\"ids\": [\"$ID1\", \"$ID2\"]}")
+STATUS_CODE=$(echo "$RESP" | grep -o '"statusCode":[0-9]*' | grep -o '[0-9]*')
+assert_eq "statusCode 200" "200" "$STATUS_CODE"
+assert_contains "response contains url" '"url"' "$RESP"
+
+echo ""
+
+# ── POST /pdf/merge → binary stream ──────────────────────────────────────────
+
+echo "--- POST /pdf/merge (stream: true) ---"
+TMP_MERGED=$(mktemp /tmp/smoke-test-merged-XXXXXX.pdf)
+HTTP_CODE=$(curl -s -X POST "$BASE/pdf/merge" \
+  -H "Content-Type: application/json" \
+  -d "{\"ids\": [\"$ID1\", \"$ID2\"], \"stream\": true}" \
+  -o "$TMP_MERGED" -w "%{http_code}")
+assert_eq "HTTP 200" "200" "$HTTP_CODE"
+
+MAGIC=$(head -c 4 "$TMP_MERGED" 2>/dev/null || true)
+if [ "$MAGIC" = "%PDF" ]; then
+  ok "merged response is a valid PDF"
+else
+  fail "merged response is not a valid PDF (magic bytes: $MAGIC)"
+fi
+rm -f "$TMP_MERGED"
+
+echo ""
+
+# ── POST /pdf/merge with < 2 ids → 400 ───────────────────────────────────────
+
+echo "--- POST /pdf/merge (< 2 ids → 400) ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/merge" \
+  -H "Content-Type: application/json" \
+  -d "{\"ids\": [\"$ID1\"]}")
+assert_eq "HTTP 400" "400" "$HTTP_CODE"
+
+echo ""
+
+# ── DELETE /pdf/:id ───────────────────────────────────────────────────────────
+
+echo "--- DELETE /pdf/:id ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$BASE/pdf/$ID1")
+assert_eq "HTTP 204" "204" "$HTTP_CODE"
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$BASE/pdf/$ID2")
+assert_eq "HTTP 204 (second delete)" "204" "$HTTP_CODE"
+
+echo ""
+
+# ── GET /metrics (after requests) ────────────────────────────────────────────
+
+echo "--- GET /metrics (after generation) ---"
+METRICS=$(curl -s "$BASE/metrics")
+assert_contains "success counter incremented" 'pdf_generation_requests_total{status="success"}' "$METRICS"
+
+echo ""
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ]

--- a/src/routes/pdf/handler.ts
+++ b/src/routes/pdf/handler.ts
@@ -1,7 +1,59 @@
 import type { FastifyReply, FastifyRequest } from 'fastify';
-import type { GenerateRequestInput } from './schema.js';
+import { PDFDocument } from 'pdf-lib';
+import type { GenerateRequestInput, PdfIdParams, MergeRequestInput } from './schema.js';
 import type { PdfService } from '../../services/pdf/PdfService.js';
 import type { StorageService } from '../../services/storage/StorageService.js';
+
+export function createGetHandler(storageService: StorageService) {
+  return async function getHandler(
+    request: FastifyRequest<{ Params: PdfIdParams }>,
+    reply: FastifyReply,
+  ) {
+    const { id } = request.params;
+    const url = await storageService.getUrl(id);
+    return reply.send({ statusCode: 200, data: { url } });
+  };
+}
+
+export function createDeleteHandler(storageService: StorageService) {
+  return async function deleteHandler(
+    request: FastifyRequest<{ Params: PdfIdParams }>,
+    reply: FastifyReply,
+  ) {
+    const { id } = request.params;
+    await storageService.delete(id);
+    return reply.code(204).send();
+  };
+}
+
+export function createMergeHandler(storageService: StorageService) {
+  return async function mergeHandler(
+    request: FastifyRequest<{ Body: MergeRequestInput }>,
+    reply: FastifyReply,
+  ) {
+    const { ids, stream } = request.body;
+
+    const pdfBuffers = await Promise.all(ids.map((id) => storageService.download(id)));
+
+    const mergedPdf = await PDFDocument.create();
+    for (const pdfBuffer of pdfBuffers) {
+      const pdf = await PDFDocument.load(pdfBuffer);
+      const pages = await mergedPdf.copyPages(pdf, pdf.getPageIndices());
+      pages.forEach((page) => mergedPdf.addPage(page));
+    }
+    const mergedBuffer = Buffer.from(await mergedPdf.save());
+
+    if (stream) {
+      return reply
+        .header('Content-Type', 'application/pdf')
+        .header('Content-Disposition', 'attachment; filename="merged.pdf"')
+        .send(mergedBuffer);
+    }
+
+    const url = await storageService.upload(mergedBuffer);
+    return reply.send({ statusCode: 200, data: { url } });
+  };
+}
 
 export function createGenerateHandler(
   pdfService: PdfService,

--- a/src/routes/pdf/index.ts
+++ b/src/routes/pdf/index.ts
@@ -1,6 +1,15 @@
 import type { FastifyPluginAsync } from 'fastify';
-import { generateRequestJsonSchema } from './schema.js';
-import { createGenerateHandler } from './handler.js';
+import {
+  generateRequestJsonSchema,
+  pdfIdParamsJsonSchema,
+  mergeRequestJsonSchema,
+} from './schema.js';
+import {
+  createGenerateHandler,
+  createGetHandler,
+  createDeleteHandler,
+  createMergeHandler,
+} from './handler.js';
 import type { PdfService } from '../../services/pdf/PdfService.js';
 import type { StorageService } from '../../services/storage/StorageService.js';
 
@@ -14,9 +23,22 @@ export const pdfRoutes: FastifyPluginAsync<PdfRouteOptions> = async (
   { pdfService, storageService },
 ) => {
   fastify.post('/pdf/generate', {
-    schema: {
-      body: generateRequestJsonSchema,
-    },
+    schema: { body: generateRequestJsonSchema },
     handler: createGenerateHandler(pdfService, storageService),
+  });
+
+  fastify.get('/pdf/:id', {
+    schema: { params: pdfIdParamsJsonSchema },
+    handler: createGetHandler(storageService),
+  });
+
+  fastify.delete('/pdf/:id', {
+    schema: { params: pdfIdParamsJsonSchema },
+    handler: createDeleteHandler(storageService),
+  });
+
+  fastify.post('/pdf/merge', {
+    schema: { body: mergeRequestJsonSchema },
+    handler: createMergeHandler(storageService),
   });
 };

--- a/src/routes/pdf/index.ts
+++ b/src/routes/pdf/index.ts
@@ -24,7 +24,7 @@ export const pdfRoutes: FastifyPluginAsync<PdfRouteOptions> = async (
   fastify,
   { pdfService, storageService, metricsService },
 ) => {
-  fastify.post('/pdf/generate', {‚
+  fastify.post('/pdf/generate', {
     schema: {
       body: generateRequestJsonSchema,
     },

--- a/src/routes/pdf/schema.ts
+++ b/src/routes/pdf/schema.ts
@@ -33,3 +33,20 @@ export type GenerateRequestInput = z.infer<typeof generateRequestSchema>;
 // draft/2020-12 meta-schema that zod v4 emits by default.
 const { $schema: _$schema, ...generateRequestJsonSchema } = z.toJSONSchema(generateRequestSchema);
 export { generateRequestJsonSchema };
+
+export const pdfIdParamsSchema = z.object({
+  id: z.string().uuid(),
+});
+export type PdfIdParams = z.infer<typeof pdfIdParamsSchema>;
+
+const { $schema: _s1, ...pdfIdParamsJsonSchema } = z.toJSONSchema(pdfIdParamsSchema);
+export { pdfIdParamsJsonSchema };
+
+export const mergeRequestSchema = z.object({
+  ids: z.array(z.string().uuid()).min(2),
+  stream: z.boolean().optional().default(false),
+});
+export type MergeRequestInput = z.infer<typeof mergeRequestSchema>;
+
+const { $schema: _s2, ...mergeRequestJsonSchema } = z.toJSONSchema(mergeRequestSchema);
+export { mergeRequestJsonSchema };

--- a/src/services/storage/StorageService.ts
+++ b/src/services/storage/StorageService.ts
@@ -2,6 +2,7 @@ import {
   S3Client,
   PutObjectCommand,
   GetObjectCommand,
+  DeleteObjectCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { randomUUID } from 'crypto';
@@ -14,6 +15,32 @@ export class StorageService {
     private readonly s3: S3Client,
     private readonly s3Public: S3Client,
   ) {}
+
+  private keyFromId(id: string): string {
+    return `pdfs/${id}.pdf`;
+  }
+
+  async getUrl(id: string): Promise<string> {
+    return getSignedUrl(
+      this.s3Public,
+      new GetObjectCommand({ Bucket: env.S3_BUCKET, Key: this.keyFromId(id) }),
+      { expiresIn: env.SIGNED_URL_EXPIRY_SECONDS },
+    );
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.s3.send(
+      new DeleteObjectCommand({ Bucket: env.S3_BUCKET, Key: this.keyFromId(id) }),
+    );
+  }
+
+  async download(id: string): Promise<Buffer> {
+    const response = await this.s3.send(
+      new GetObjectCommand({ Bucket: env.S3_BUCKET, Key: this.keyFromId(id) }),
+    );
+    const bytes = await response.Body!.transformToByteArray();
+    return Buffer.from(bytes);
+  }
 
   async upload(pdfBuffer: Buffer): Promise<string> {
     const key = `pdfs/${randomUUID()}.pdf`;

--- a/test/integration/delete.test.ts
+++ b/test/integration/delete.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+vi.mock('../../src/config/env.js', () => ({
+  env: {
+    S3_BUCKET: 'test-bucket',
+    AWS_REGION: 'us-east-1',
+    SIGNED_URL_EXPIRY_SECONDS: 3600,
+    LOG_LEVEL: 'error',
+    PORT: 8080,
+  },
+}));
+
+vi.mock('../../src/services/pdf/PdfService.js', () => ({
+  PdfService: class {
+    getBrowser = vi.fn().mockResolvedValue({});
+    generate = vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 test'));
+    close = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../../src/services/storage/StorageService.js', () => ({
+  StorageService: class {
+    upload = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+    getUrl = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+    delete = vi.fn().mockResolvedValue(undefined);
+    download = vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 test'));
+  },
+}));
+
+vi.mock('../../src/plugins/s3.js', () => ({
+  s3Plugin: async (fastify: FastifyInstance) => {
+    fastify.decorate('s3', {});
+    fastify.decorate('s3Public', {});
+  },
+}));
+
+const VALID_UUID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+describe('DELETE /pdf/:id', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const { buildApp } = await import('../../src/server.js');
+    app = await buildApp();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns 204 for a valid UUID', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/pdf/${VALID_UUID}`,
+    });
+
+    expect(response.statusCode).toBe(204);
+  });
+
+  it('returns 400 for an invalid (non-UUID) id', async () => {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: '/pdf/not-a-uuid',
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+});

--- a/test/integration/get.test.ts
+++ b/test/integration/get.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+vi.mock('../../src/config/env.js', () => ({
+  env: {
+    S3_BUCKET: 'test-bucket',
+    AWS_REGION: 'us-east-1',
+    SIGNED_URL_EXPIRY_SECONDS: 3600,
+    LOG_LEVEL: 'error',
+    PORT: 8080,
+  },
+}));
+
+vi.mock('../../src/services/pdf/PdfService.js', () => ({
+  PdfService: class {
+    getBrowser = vi.fn().mockResolvedValue({});
+    generate = vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 test'));
+    close = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../../src/services/storage/StorageService.js', () => ({
+  StorageService: class {
+    upload = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+    getUrl = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+    delete = vi.fn().mockResolvedValue(undefined);
+    download = vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 test'));
+  },
+}));
+
+vi.mock('../../src/plugins/s3.js', () => ({
+  s3Plugin: async (fastify: FastifyInstance) => {
+    fastify.decorate('s3', {});
+    fastify.decorate('s3Public', {});
+  },
+}));
+
+const VALID_UUID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+
+describe('GET /pdf/:id', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const { buildApp } = await import('../../src/server.js');
+    app = await buildApp();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns a presigned URL for a valid UUID', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/pdf/${VALID_UUID}`,
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toMatchObject({
+      statusCode: 200,
+      data: { url: expect.stringContaining('https://') },
+    });
+  });
+
+  it('returns 400 for an invalid (non-UUID) id', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/pdf/not-a-uuid',
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+});

--- a/test/integration/merge.test.ts
+++ b/test/integration/merge.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { PDFDocument } from 'pdf-lib';
+import type { FastifyInstance } from 'fastify';
+
+vi.mock('../../src/config/env.js', () => ({
+  env: {
+    S3_BUCKET: 'test-bucket',
+    AWS_REGION: 'us-east-1',
+    SIGNED_URL_EXPIRY_SECONDS: 3600,
+    LOG_LEVEL: 'error',
+    PORT: 8080,
+  },
+}));
+
+vi.mock('../../src/services/pdf/PdfService.js', () => ({
+  PdfService: class {
+    getBrowser = vi.fn().mockResolvedValue({});
+    generate = vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 test'));
+    close = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+// Provide a real minimal PDF buffer so pdf-lib can load it during the merge
+let minimalPdfBuffer: Buffer;
+
+vi.mock('../../src/services/storage/StorageService.js', () => ({
+  StorageService: class {
+    upload = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/merged.pdf?signed=true');
+    getUrl = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+    delete = vi.fn().mockResolvedValue(undefined);
+    download = vi.fn().mockImplementation(() => Promise.resolve(minimalPdfBuffer));
+  },
+}));
+
+vi.mock('../../src/plugins/s3.js', () => ({
+  s3Plugin: async (fastify: FastifyInstance) => {
+    fastify.decorate('s3', {});
+    fastify.decorate('s3Public', {});
+  },
+}));
+
+const UUID1 = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+const UUID2 = 'b1ffcd00-0d1c-4f09-8c7e-7cc0ce491b22';
+
+describe('POST /pdf/merge', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const doc = await PDFDocument.create();
+    doc.addPage();
+    minimalPdfBuffer = Buffer.from(await doc.save());
+
+    const { buildApp } = await import('../../src/server.js');
+    app = await buildApp();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns a presigned URL when stream is false', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/merge',
+      payload: { ids: [UUID1, UUID2] },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toMatchObject({
+      statusCode: 200,
+      data: { url: expect.stringContaining('https://') },
+    });
+  });
+
+  it('returns binary PDF when stream is true', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/merge',
+      payload: { ids: [UUID1, UUID2], stream: true },
+    });
+
+    expect(response.statusCode).toBe(200);
+    expect(response.headers['content-type']).toContain('application/pdf');
+  });
+
+  it('returns 400 when fewer than 2 IDs are provided', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/merge',
+      payload: { ids: [UUID1] },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('returns 400 for non-UUID ids', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/merge',
+      payload: { ids: ['not-a-uuid', 'also-not-a-uuid'] },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION
- GET /pdf/:id returns a fresh presigned S3 URL for an existing PDF
- DELETE /pdf/:id removes a PDF from S3 (204 No Content)
- POST /pdf/merge merges multiple PDFs by UUID using pdf-lib, supports stream and S3 upload modes
- Extended StorageService with getUrl, delete, and download methods
- Added pdfIdParamsSchema and mergeRequestSchema (Zod) with Fastify JSON Schema integration
- Integration tests for all three new routes

https://claude.ai/code/session_016UdvurpX2f9GghWYFEVSro