### PR TITLE
Add API key authentication with timing-safe comparison

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ AWS_SECRET_ACCESS_KEY=minioadmin
 # Optional
 SIGNED_URL_EXPIRY_SECONDS=3600
 LOG_LEVEL=info
+
+# API authentication (recommended in production, minimum 32 characters)
+# API_KEY=your-secret-key-minimum-32-chars

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ src/
   lambda.ts              # Lambda handler — buildApp() called via promise at module level
   config/env.ts          # Zod-parsed process.env, process.exit(1) on missing required vars
   plugins/
+    auth.ts              # API key auth (X-Api-Key header, timing-safe comparison); skipped when API_KEY unset
     s3.ts                # Registers s3 (upload) + s3Public (presigning) as Fastify decorators
     sensible.ts          # @fastify/sensible
   routes/
@@ -48,6 +49,12 @@ src/
     index.ts                   # GenerateRequest, PaperOptions, PdfOptions, GenerateResponse
     aws-lambda-fastify.d.ts    # Ambient declaration for aws-lambda-fastify (no types shipped)
 ```
+
+## Authentication
+
+All routes are protected by a static API key when the `API_KEY` environment variable is set (min 32 chars). Clients must pass the key in the `X-Api-Key` request header. Requests without a valid key receive `401 Unauthorized`. When `API_KEY` is unset, auth is skipped (local dev). Comparison uses `crypto.timingSafeEqual` to prevent timing attacks.
+
+**Files:** `src/plugins/auth.ts`, `src/plugins/auth.test.ts`, `test/integration/auth.test.ts`
 
 ## API
 
@@ -216,6 +223,7 @@ npm run build
 | `SIGNED_URL_EXPIRY_SECONDS` | no | Default: `3600` |
 | `LOG_LEVEL` | no | Default: `info` |
 | `PORT` | no | Default: `8080` |
+| `API_KEY` | recommended in prod | Static API key (min 32 chars). Omit to disable auth. |
 
 ## Testing Strategy
 
@@ -233,7 +241,7 @@ Planned features are documented in `.plans/`:
 | `css-injection.md` | Inject extra CSS before rendering | Implemented |
 | `url-rendering.md` | Render a URL instead of raw HTML (includes SSRF notes) | Planned |
 | `async-webhook.md` | `202 Accepted` + webhook callback for slow jobs | Planned |
-| `api-key-auth.md` | `X-Api-Key` header auth with timing-safe comparison | Planned |
+| `api-key-auth.md` | `X-Api-Key` header auth with timing-safe comparison | Implemented |
 | `observability.md` | `/health`, `/metrics`, PDF generation histograms | Implemented |
 | `additional-routes.md` | `GET /pdf/:id`, `DELETE /pdf/:id`, `POST /pdf/merge` | Implemented |
 | `queue-based-scaling.md` | SQS / BullMQ decoupled worker tier | Planned |

--- a/README.md
+++ b/README.md
@@ -218,6 +218,23 @@ npm run dev
 | `npm run lint` | ESLint |
 | `npm run build` | Bundle with esbuild to `dist/` |
 
+## Authentication
+
+All routes can be protected with a static API key passed in the `X-Api-Key` request header.
+
+- Set the `API_KEY` environment variable (minimum 32 characters) to enable authentication.
+- When `API_KEY` is not set, authentication is skipped (useful for local development).
+- Unauthenticated requests receive a `401 Unauthorized` response before reaching any handler.
+- Key comparison uses constant-time (`crypto.timingSafeEqual`) to prevent timing attacks.
+
+```bash
+# Example authenticated request
+curl -X POST http://localhost:8080/pdf/generate \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: your-secret-key-here" \
+  -d '{"html": "<html><body><h1>Hello</h1></body></html>"}'
+```
+
 ## Environment variables
 
 | Variable | Required | Description |
@@ -231,6 +248,7 @@ npm run dev
 | `SIGNED_URL_EXPIRY_SECONDS` | no | Presigned URL TTL, default `3600` |
 | `LOG_LEVEL` | no | `trace` `debug` `info` `warn` `error` — default `info` |
 | `PORT` | no | HTTP port for local server, default `8080` |
+| `API_KEY` | recommended in prod | Static API key for request authentication (min 32 chars). Omit to disable auth. |
 
 See [.env.example](.env.example) for a ready-to-copy template.
 
@@ -252,6 +270,7 @@ src/
   lambda.ts              # Lambda handler — buildApp() at module level for browser reuse
   config/env.ts          # Zod-parsed process.env — exits on missing required vars
   plugins/
+    auth.ts              # API key authentication (X-Api-Key header, timing-safe comparison)
     s3.ts                # Registers s3 (upload) and s3Public (presigning) decorators
     sensible.ts          # @fastify/sensible (httpErrors, assert)
   routes/

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -2,6 +2,7 @@
 # smoke-test.sh — end-to-end test of all PDF microservice routes
 # Usage: ./scripts/smoke-test.sh [BASE_URL]
 # Default BASE_URL: http://localhost:8080
+# Set API_KEY env var if the server requires authentication.
 
 set -euo pipefail
 
@@ -49,8 +50,20 @@ extract_id() {
   echo "$1" | sed 's|.*pdfs/\([^.]*\)\.pdf.*|\1|'
 }
 
+# Build auth header args for curl; empty if no API_KEY set
+auth_header() {
+  if [ -n "${API_KEY:-}" ]; then
+    echo "-H" "x-api-key: $API_KEY"
+  fi
+}
+
 echo "=== PDF Microservice Smoke Test ==="
 echo "Base URL: $BASE"
+if [ -n "${API_KEY:-}" ]; then
+  echo "Auth:     API key provided"
+else
+  echo "Auth:     none (set API_KEY to test authenticated endpoints)"
+fi
 echo ""
 
 # ── GET /health ───────────────────────────────────────────────────────────────
@@ -77,10 +90,30 @@ assert_contains "requests counter present"   "pdf_generation_requests_total"    
 
 echo ""
 
+# ── Auth: 401 when API_KEY is configured and header is missing ────────────────
+
+if [ -n "${API_KEY:-}" ]; then
+  echo "--- Auth: missing x-api-key → 401 ---"
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+    -H "Content-Type: application/json" \
+    -d '{"html": "<h1>test</h1>"}')
+  assert_eq "HTTP 401 (no key)" "401" "$HTTP_CODE"
+
+  echo "--- Auth: wrong x-api-key → 401 ---"
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+    -H "Content-Type: application/json" \
+    -H "x-api-key: wrong-key" \
+    -d '{"html": "<h1>test</h1>"}')
+  assert_eq "HTTP 401 (wrong key)" "401" "$HTTP_CODE"
+
+  echo ""
+fi
+
 # ── POST /pdf/generate → S3 URL ───────────────────────────────────────────────
 
 echo "--- POST /pdf/generate (stream: false) ---"
 RESP=$(curl -s -X POST "$BASE/pdf/generate" \
+  $(auth_header) \
   -H "Content-Type: application/json" \
   -d '{
     "html": "<html><body><h1>Smoke Test Page 1</h1></body></html>",
@@ -104,6 +137,7 @@ echo ""
 echo "--- POST /pdf/generate (stream: true) ---"
 TMP_PDF=$(mktemp /tmp/smoke-test-XXXXXX.pdf)
 HTTP_CODE=$(curl -s -X POST "$BASE/pdf/generate" \
+  $(auth_header) \
   -H "Content-Type: application/json" \
   -d '{"html": "<html><body><h1>Smoke Test Page 2</h1></body></html>", "stream": true}' \
   -o "$TMP_PDF" -w "%{http_code}")
@@ -124,6 +158,7 @@ echo ""
 # Generate a second PDF for merge/delete tests
 echo "--- POST /pdf/generate (second PDF for merge) ---"
 RESP2=$(curl -s -X POST "$BASE/pdf/generate" \
+  $(auth_header) \
   -H "Content-Type: application/json" \
   -d '{"html": "<html><body><h1>Smoke Test Page 2</h1></body></html>"}')
 URL2=$(echo "$RESP2" | sed 's/.*"url":"\([^"]*\)".*/\1/')
@@ -136,7 +171,7 @@ echo ""
 # ── GET /pdf/:id ──────────────────────────────────────────────────────────────
 
 echo "--- GET /pdf/:id ---"
-RESP=$(curl -s "$BASE/pdf/$ID1")
+RESP=$(curl -s $(auth_header) "$BASE/pdf/$ID1")
 STATUS_CODE=$(echo "$RESP" | grep -o '"statusCode":[0-9]*' | grep -o '[0-9]*')
 assert_eq "statusCode 200" "200" "$STATUS_CODE"
 assert_contains "response contains url" '"url"' "$RESP"
@@ -146,7 +181,7 @@ echo ""
 # ── GET /pdf/:id with invalid UUID ───────────────────────────────────────────
 
 echo "--- GET /pdf/:id (invalid UUID → 400) ---"
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/pdf/not-a-uuid")
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" $(auth_header) "$BASE/pdf/not-a-uuid")
 assert_eq "HTTP 400" "400" "$HTTP_CODE"
 
 echo ""
@@ -155,6 +190,7 @@ echo ""
 
 echo "--- POST /pdf/merge (stream: false) ---"
 RESP=$(curl -s -X POST "$BASE/pdf/merge" \
+  $(auth_header) \
   -H "Content-Type: application/json" \
   -d "{\"ids\": [\"$ID1\", \"$ID2\"]}")
 STATUS_CODE=$(echo "$RESP" | grep -o '"statusCode":[0-9]*' | grep -o '[0-9]*')
@@ -168,6 +204,7 @@ echo ""
 echo "--- POST /pdf/merge (stream: true) ---"
 TMP_MERGED=$(mktemp /tmp/smoke-test-merged-XXXXXX.pdf)
 HTTP_CODE=$(curl -s -X POST "$BASE/pdf/merge" \
+  $(auth_header) \
   -H "Content-Type: application/json" \
   -d "{\"ids\": [\"$ID1\", \"$ID2\"], \"stream\": true}" \
   -o "$TMP_MERGED" -w "%{http_code}")
@@ -187,6 +224,7 @@ echo ""
 
 echo "--- POST /pdf/merge (< 2 ids → 400) ---"
 HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/merge" \
+  $(auth_header) \
   -H "Content-Type: application/json" \
   -d "{\"ids\": [\"$ID1\"]}")
 assert_eq "HTTP 400" "400" "$HTTP_CODE"
@@ -196,10 +234,10 @@ echo ""
 # ── DELETE /pdf/:id ───────────────────────────────────────────────────────────
 
 echo "--- DELETE /pdf/:id ---"
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$BASE/pdf/$ID1")
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE $(auth_header) "$BASE/pdf/$ID1")
 assert_eq "HTTP 204" "204" "$HTTP_CODE"
 
-HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE "$BASE/pdf/$ID2")
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X DELETE $(auth_header) "$BASE/pdf/$ID2")
 assert_eq "HTTP 204 (second delete)" "204" "$HTTP_CODE"
 
 echo ""

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -10,6 +10,7 @@ const envSchema = z.object({
   SIGNED_URL_EXPIRY_SECONDS: z.coerce.number().int().positive().default(3600),
   LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error']).default('info'),
   PORT: z.coerce.number().int().positive().default(8080),
+  API_KEY: z.string().min(32).optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/plugins/auth.test.ts
+++ b/src/plugins/auth.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import Fastify, { type FastifyInstance } from 'fastify';
+
+const TEST_API_KEY = 'test-api-key-that-is-at-least-32-characters-long';
+
+describe('authPlugin', () => {
+  describe('when API_KEY is set', () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      vi.doMock('../config/env.js', () => ({
+        env: { API_KEY: TEST_API_KEY },
+      }));
+
+      const { authPlugin } = await import('./auth.js');
+
+      app = Fastify({ logger: false });
+      await app.register(authPlugin);
+      app.get('/test', async () => ({ ok: true }));
+      await app.ready();
+    });
+
+    afterAll(async () => {
+      await app.close();
+      vi.restoreAllMocks();
+    });
+
+    it('returns 401 when x-api-key header is missing', async () => {
+      const response = await app.inject({ method: 'GET', url: '/test' });
+      expect(response.statusCode).toBe(401);
+      expect(response.json()).toEqual({ statusCode: 401, error: 'Unauthorized' });
+    });
+
+    it('returns 401 when x-api-key header is wrong', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/test',
+        headers: { 'x-api-key': 'wrong-key-but-still-at-least-32-chars!!' },
+      });
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('passes through when x-api-key header is correct', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/test',
+        headers: { 'x-api-key': TEST_API_KEY },
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ ok: true });
+    });
+  });
+
+  describe('when API_KEY is not set', () => {
+    let app: FastifyInstance;
+
+    beforeAll(async () => {
+      vi.resetModules();
+      vi.doMock('../config/env.js', () => ({
+        env: { API_KEY: undefined },
+      }));
+
+      const { authPlugin } = await import('./auth.js');
+
+      app = Fastify({ logger: false });
+      await app.register(authPlugin);
+      app.get('/test', async () => ({ ok: true }));
+      await app.ready();
+    });
+
+    afterAll(async () => {
+      await app.close();
+      vi.restoreAllMocks();
+    });
+
+    it('allows requests without x-api-key header', async () => {
+      const response = await app.inject({ method: 'GET', url: '/test' });
+      expect(response.statusCode).toBe(200);
+      expect(response.json()).toEqual({ ok: true });
+    });
+  });
+});

--- a/src/plugins/auth.ts
+++ b/src/plugins/auth.ts
@@ -1,0 +1,18 @@
+import { timingSafeEqual } from 'node:crypto';
+import fp from 'fastify-plugin';
+import { env } from '../config/env.js';
+
+export const authPlugin = fp(async (fastify) => {
+  if (!env.API_KEY) return;
+
+  const expected = Buffer.from(env.API_KEY);
+
+  fastify.addHook('onRequest', async (request, reply) => {
+    const key = request.headers['x-api-key'];
+    const provided = Buffer.from(typeof key === 'string' ? key : '');
+
+    if (expected.length !== provided.length || !timingSafeEqual(expected, provided)) {
+      return reply.status(401).send({ statusCode: 401, error: 'Unauthorized' });
+    }
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,5 +1,6 @@
 import Fastify from 'fastify';
 import { env } from './config/env.js';
+import { authPlugin } from './plugins/auth.js';
 import { s3Plugin } from './plugins/s3.js';
 import { sensiblePlugin } from './plugins/sensible.js';
 import { healthRoutes } from './routes/health/index.js';
@@ -24,6 +25,7 @@ export async function buildApp() {
   const metricsService = new MetricsService();
 
   await fastify.register(sensiblePlugin);
+  await fastify.register(authPlugin);
   await fastify.register(s3Plugin);
   await fastify.register(healthRoutes);
   await fastify.register(pdfRoutes, {

--- a/test/integration/auth.test.ts
+++ b/test/integration/auth.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+const TEST_API_KEY = 'integration-test-key-minimum-32-characters-long';
+
+vi.mock('../../src/config/env.js', () => ({
+  env: {
+    S3_BUCKET: 'test-bucket',
+    AWS_REGION: 'us-east-1',
+    SIGNED_URL_EXPIRY_SECONDS: 3600,
+    LOG_LEVEL: 'error',
+    PORT: 8080,
+    API_KEY: TEST_API_KEY,
+  },
+}));
+
+vi.mock('../../src/services/pdf/PdfService.js', () => ({
+  PdfService: class {
+    getBrowser = vi.fn().mockResolvedValue({});
+    generate = vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 test'));
+    close = vi.fn().mockResolvedValue(undefined);
+  },
+}));
+
+vi.mock('../../src/services/storage/StorageService.js', () => ({
+  StorageService: class {
+    upload = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+  },
+}));
+
+vi.mock('../../src/plugins/s3.js', () => ({
+  s3Plugin: async (fastify: FastifyInstance) => {
+    fastify.decorate('s3', {});
+    fastify.decorate('s3Public', {});
+  },
+}));
+
+describe('API key authentication (integration)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    const { buildApp } = await import('../../src/server.js');
+    app = await buildApp();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns 401 for requests without x-api-key header', async () => {
+    const response = await app.inject({ method: 'GET', url: '/health' });
+    expect(response.statusCode).toBe(401);
+    expect(response.json()).toEqual({ statusCode: 401, error: 'Unauthorized' });
+  });
+
+  it('returns 401 for requests with wrong x-api-key', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/health',
+      headers: { 'x-api-key': 'wrong-key-that-is-at-least-32-characters!' },
+    });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('allows requests with correct x-api-key', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: '/health',
+      headers: { 'x-api-key': TEST_API_KEY },
+    });
+    expect(response.statusCode).toBe(200);
+    expect(response.json()).toEqual({ status: 'ok' });
+  });
+
+  it('returns 401 on POST /pdf/generate without key', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      payload: { html: '<html><body>Test</body></html>' },
+    });
+    expect(response.statusCode).toBe(401);
+  });
+
+  it('allows POST /pdf/generate with correct key', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      headers: { 'x-api-key': TEST_API_KEY },
+      payload: { html: '<html><body>Test</body></html>' },
+    });
+    expect(response.statusCode).toBe(200);
+  });
+});


### PR DESCRIPTION
Protect all routes with a static API key passed via the X-Api-Key header. Uses crypto.timingSafeEqual to prevent timing attacks. Auth is skipped when API_KEY env var is unset, making local dev frictionless.

https://claude.ai/code/session_01X1Q8QC3ueEphWfN2oskBdc