### PR TITLE
Add PDF operations: split, compress, and PDF/A conversion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,8 @@ Runs as both a Docker container (local dev) and an AWS Lambda container image (p
 |---|---|---|
 | Framework | Fastify | 5.x |
 | PDF rendering | puppeteer-core + @sparticuz/chromium | 24.x / 143.x |
-| PDF merging | pdf-lib | 1.x |
+| PDF manipulation | pdf-lib | 1.x |
+| PDF compression / PDF/A | Ghostscript (optional, via `GHOSTSCRIPT_PATH`) | — |
 | Validation | Zod | 4.x |
 | Storage | @aws-sdk/client-s3 | 3.x |
 | Logging | Pino (Fastify built-in) + pino-pretty | — |
@@ -42,9 +43,10 @@ src/
       handler.ts         # generate PDF → stream bytes or upload to S3 + return presigned URL
       index.ts           # Registers POST /pdf/generate
   services/
-    pdf/PdfService.ts          # Puppeteer browser lifecycle + PDF generation
-    storage/StorageService.ts  # S3 upload (s3 client) + presigned URL (s3Public client)
-    metrics/MetricsService.ts  # In-memory histograms + counter; serialises to Prometheus text
+    pdf/PdfService.ts               # Puppeteer browser lifecycle + PDF generation
+    pdf/PdfOperationsService.ts     # split (pdf-lib), compress + PDF/A (Ghostscript / pdf-lib fallback)
+    storage/StorageService.ts       # S3 upload (s3 client) + presigned URL (s3Public client)
+    metrics/MetricsService.ts       # In-memory histograms + counter; serialises to Prometheus text
   types/
     index.ts                   # GenerateRequest, PaperOptions, PdfOptions, GenerateResponse
     aws-lambda-fastify.d.ts    # Ambient declaration for aws-lambda-fastify (no types shipped)
@@ -172,6 +174,75 @@ All source PDFs are fetched in parallel (`Promise.all`). Pages are copied in the
 
 **Files:** `src/routes/pdf/index.ts`, `src/routes/pdf/handler.ts` (`createMergeHandler`), `src/services/storage/StorageService.ts` (`download`, `upload`)
 
+---
+
+### POST /pdf/split
+
+Extracts a subset of pages from an existing PDF using `pdf-lib`.
+
+**Request body:**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "pages": "1-3,5,7-",
+  "stream": false
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | UUID | yes | Source PDF ID |
+| `pages` | string | yes | Page range expression: `"1-3"` (range), `"1,3,5"` (comma list), `"2-"` (open-ended) |
+| `stream` | boolean | no | `true` = binary, `false` = S3 URL (default) |
+
+Page numbers are 1-based. Ranges are inclusive. Out-of-range indices are silently dropped. Duplicates are deduplicated. Returns `500` if the expression yields no valid pages.
+
+**Files:** `src/routes/pdf/handler.ts` (`createSplitHandler`), `src/services/pdf/PdfOperationsService.ts` (`split`, `parsePageRange`)
+
+---
+
+### POST /pdf/compress
+
+Reduces file size of an existing PDF. Always available — uses Ghostscript (`-dPDFSETTINGS=/ebook`) when `GHOSTSCRIPT_PATH` is set; falls back to `pdf-lib` re-save with `useObjectStreams: true` otherwise.
+
+**Request body:**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "stream": false
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | UUID | yes | Source PDF ID |
+| `stream` | boolean | no | `true` = binary, `false` = S3 URL (default) |
+
+**Files:** `src/routes/pdf/handler.ts` (`createCompressHandler`), `src/services/pdf/PdfOperationsService.ts` (`compress`, `ghostscriptCompress`)
+
+---
+
+### POST /pdf/pdfa
+
+Converts an existing PDF to PDF/A using Ghostscript. **Route is only registered when `GHOSTSCRIPT_PATH` is set.**
+
+**Request body:**
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "conformance": "2b",
+  "stream": false
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | UUID | yes | Source PDF ID |
+| `conformance` | `"1b"` \| `"2b"` \| `"3b"` | no | PDF/A conformance level (default `"2b"`) |
+| `stream` | boolean | no | `true` = binary, `false` = S3 URL (default) |
+
+**Files:** `src/routes/pdf/handler.ts` (`createPdfAHandler`), `src/services/pdf/PdfOperationsService.ts` (`convertToPdfA`, `ghostscriptPdfA`)
+
 ## Key Decisions
 
 1. **Browser reuse**: `PdfService` holds the `Browser` instance at class level. `lambda.ts` calls `buildApp()` outside the handler via a module-level promise — Lambda freezes the process between invocations, so the browser survives and is reused on warm calls.
@@ -187,6 +258,8 @@ All source PDFs are fetched in parallel (`Promise.all`). Pages are copied in the
 6. **`--no-sandbox`**: `@sparticuz/chromium` sets this automatically via its `args` export. Always use `chromium.args`, `chromium.executablePath()`, and `chromium.headless` when launching.
 
 7. **`platform: linux/amd64`** in `docker-compose.yml`: `@sparticuz/chromium` ships only x86_64 binaries. On Apple Silicon, Docker must build/run under Rosetta 2 emulation.
+
+8. **Ghostscript gating**: `POST /pdf/compress` always exists (pdf-lib fallback), while `POST /pdf/pdfa` is only registered when `GHOSTSCRIPT_PATH` is set (`opsService.canUseGhostscript`). Ghostscript operations write to unique temp files in `os.tmpdir()` and clean up via `Promise.allSettled` in a `finally` block — even if Ghostscript fails.
 
 ## Development
 
@@ -224,6 +297,7 @@ npm run build
 | `LOG_LEVEL` | no | Default: `info` |
 | `PORT` | no | Default: `8080` |
 | `API_KEY` | recommended in prod | Static API key (min 32 chars). Omit to disable auth. |
+| `GHOSTSCRIPT_PATH` | no | Path to the `gs` binary (e.g. `/usr/bin/gs`). Enables Ghostscript-based compression and activates `POST /pdf/pdfa`. |
 
 ## Testing Strategy
 
@@ -244,5 +318,6 @@ Planned features are documented in `.plans/`:
 | `api-key-auth.md` | `X-Api-Key` header auth with timing-safe comparison | Implemented |
 | `observability.md` | `/health`, `/metrics`, PDF generation histograms | Implemented |
 | `additional-routes.md` | `GET /pdf/:id`, `DELETE /pdf/:id`, `POST /pdf/merge` | Implemented |
+| `pdf-operations.md` | `POST /pdf/split`, `POST /pdf/compress`, `POST /pdf/pdfa` | Implemented |
 | `queue-based-scaling.md` | SQS / BullMQ decoupled worker tier | Planned |
 | `node-server-deployment.md` | ECS Fargate / Fly.io plain Node server deployment | Planned |

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf install -y \
       alsa-lib \
       atk \
       cups-libs \
+      ghostscript \
       gtk3 \
       libX11 \
       libXcomposite \

--- a/README.md
+++ b/README.md
@@ -177,6 +177,112 @@ Content-Disposition: attachment; filename="merged.pdf"
 <binary PDF bytes>
 ```
 
+---
+
+### `POST /pdf/split`
+
+Extracts a subset of pages from an existing PDF.
+
+**Request**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "pages": "1-3,5,7-",
+  "stream": false
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | UUID | yes | Source PDF ID |
+| `pages` | string | yes | Page range: `"1-3"` (range), `"1,3,5"` (list), `"2-"` (from page 2 to end) |
+| `stream` | boolean | no | `true` = binary response, `false` = S3 URL (default) |
+
+**Response — S3 URL (`stream: false`)**
+
+```json
+{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+```
+
+**Response — binary stream (`stream: true`)**
+
+```
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="split.pdf"
+<binary PDF bytes>
+```
+
+---
+
+### `POST /pdf/compress`
+
+Reduces the file size of an existing PDF. Uses Ghostscript when `GHOSTSCRIPT_PATH` is set (re-encodes images and streams); otherwise falls back to re-saving with `pdf-lib` object streams (reduces xref table size for text-heavy documents).
+
+**Request**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "stream": false
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | UUID | yes | Source PDF ID |
+| `stream` | boolean | no | `true` = binary response, `false` = S3 URL (default) |
+
+**Response — S3 URL (`stream: false`)**
+
+```json
+{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+```
+
+**Response — binary stream (`stream: true`)**
+
+```
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="compressed.pdf"
+<binary PDF bytes>
+```
+
+---
+
+### `POST /pdf/pdfa`
+
+Converts an existing PDF to PDF/A for long-term archival compliance. **Requires `GHOSTSCRIPT_PATH` to be set** — the route is not registered otherwise.
+
+**Request**
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "conformance": "2b",
+  "stream": false
+}
+```
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `id` | UUID | yes | Source PDF ID |
+| `conformance` | `"1b"` \| `"2b"` \| `"3b"` | no | PDF/A conformance level (default `"2b"`) |
+| `stream` | boolean | no | `true` = binary response, `false` = S3 URL (default) |
+
+**Response — S3 URL (`stream: false`)**
+
+```json
+{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+```
+
+**Response — binary stream (`stream: true`)**
+
+```
+Content-Type: application/pdf
+Content-Disposition: attachment; filename="pdfa.pdf"
+<binary PDF bytes>
+```
+
 ## Local development
 
 Prerequisites: Docker and Docker Compose.
@@ -249,6 +355,7 @@ curl -X POST http://localhost:8080/pdf/generate \
 | `LOG_LEVEL` | no | `trace` `debug` `info` `warn` `error` — default `info` |
 | `PORT` | no | HTTP port for local server, default `8080` |
 | `API_KEY` | recommended in prod | Static API key for request authentication (min 32 chars). Omit to disable auth. |
+| `GHOSTSCRIPT_PATH` | no | Path to the `gs` binary. Enables real image compression on `POST /pdf/compress` and activates the `POST /pdf/pdfa` route. |
 
 See [.env.example](.env.example) for a ready-to-copy template.
 
@@ -284,9 +391,10 @@ src/
       handler.ts         # Orchestration: generate PDF → stream or upload to S3
       index.ts           # Route registration (POST /pdf/generate)
   services/
-    pdf/PdfService.ts          # Puppeteer browser lifecycle + PDF generation
-    storage/StorageService.ts  # S3 upload (s3) + presigned URL (s3Public)
-    metrics/MetricsService.ts  # In-memory Prometheus metrics (histograms + counters)
+    pdf/PdfService.ts               # Puppeteer browser lifecycle + PDF generation
+    pdf/PdfOperationsService.ts     # split (pdf-lib), compress + PDF/A (Ghostscript / pdf-lib fallback)
+    storage/StorageService.ts       # S3 upload (s3) + presigned URL (s3Public)
+    metrics/MetricsService.ts       # In-memory Prometheus metrics (histograms + counters)
   types/
     index.ts                   # Shared TypeScript interfaces
     aws-lambda-fastify.d.ts    # Ambient type declaration for aws-lambda-fastify

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,7 @@ export default tseslint.config(
   {
     rules: {
       '@typescript-eslint/no-unused-vars': ['warn', { varsIgnorePattern: '^_', argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'warn',
     },
   },
 );

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -231,6 +231,98 @@ assert_eq "HTTP 400" "400" "$HTTP_CODE"
 
 echo ""
 
+# ── POST /pdf/split → binary stream ──────────────────────────────────────────
+
+echo "--- POST /pdf/split (stream: true) ---"
+TMP_SPLIT=$(mktemp /tmp/smoke-test-split-XXXXXX.pdf)
+HTTP_CODE=$(curl -s -X POST "$BASE/pdf/split" \
+  $(auth_header) \
+  -H "Content-Type: application/json" \
+  -d "{\"id\": \"$ID1\", \"pages\": \"1\", \"stream\": true}" \
+  -o "$TMP_SPLIT" -w "%{http_code}")
+assert_eq "HTTP 200" "200" "$HTTP_CODE"
+
+MAGIC=$(head -c 4 "$TMP_SPLIT" 2>/dev/null || true)
+if [ "$MAGIC" = "%PDF" ]; then
+  ok "split response is a valid PDF"
+else
+  fail "split response is not a valid PDF (magic bytes: $MAGIC)"
+fi
+rm -f "$TMP_SPLIT"
+
+echo ""
+
+# ── POST /pdf/split → S3 URL ──────────────────────────────────────────────────
+
+echo "--- POST /pdf/split (stream: false) ---"
+RESP=$(curl -s -X POST "$BASE/pdf/split" \
+  $(auth_header) \
+  -H "Content-Type: application/json" \
+  -d "{\"id\": \"$ID1\", \"pages\": \"1\"}")
+STATUS_CODE=$(echo "$RESP" | grep -o '"statusCode":[0-9]*' | grep -o '[0-9]*')
+assert_eq "statusCode 200" "200" "$STATUS_CODE"
+assert_contains "split response contains url" '"url"' "$RESP"
+
+echo ""
+
+# ── POST /pdf/split with missing pages field → 400 ───────────────────────────
+
+echo "--- POST /pdf/split (missing pages → 400) ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/split" \
+  $(auth_header) \
+  -H "Content-Type: application/json" \
+  -d "{\"id\": \"$ID1\"}")
+assert_eq "HTTP 400" "400" "$HTTP_CODE"
+
+echo ""
+
+# ── POST /pdf/compress → binary stream ───────────────────────────────────────
+
+echo "--- POST /pdf/compress (stream: true) ---"
+TMP_COMPRESSED=$(mktemp /tmp/smoke-test-compressed-XXXXXX.pdf)
+HTTP_CODE=$(curl -s -X POST "$BASE/pdf/compress" \
+  $(auth_header) \
+  -H "Content-Type: application/json" \
+  -d "{\"id\": \"$ID1\", \"stream\": true}" \
+  -o "$TMP_COMPRESSED" -w "%{http_code}")
+assert_eq "HTTP 200" "200" "$HTTP_CODE"
+
+MAGIC=$(head -c 4 "$TMP_COMPRESSED" 2>/dev/null || true)
+if [ "$MAGIC" = "%PDF" ]; then
+  ok "compress response is a valid PDF"
+else
+  fail "compress response is not a valid PDF (magic bytes: $MAGIC)"
+fi
+rm -f "$TMP_COMPRESSED"
+
+echo ""
+
+# ── POST /pdf/pdfa (only when Ghostscript is available) ───────────────────────
+
+if [ -n "${GHOSTSCRIPT_PATH:-}" ]; then
+  echo "--- POST /pdf/pdfa (stream: true) ---"
+  TMP_PDFA=$(mktemp /tmp/smoke-test-pdfa-XXXXXX.pdf)
+  HTTP_CODE=$(curl -s -X POST "$BASE/pdf/pdfa" \
+    $(auth_header) \
+    -H "Content-Type: application/json" \
+    -d "{\"id\": \"$ID1\", \"conformance\": \"2b\", \"stream\": true}" \
+    -o "$TMP_PDFA" -w "%{http_code}")
+  assert_eq "HTTP 200" "200" "$HTTP_CODE"
+
+  MAGIC=$(head -c 4 "$TMP_PDFA" 2>/dev/null || true)
+  if [ "$MAGIC" = "%PDF" ]; then
+    ok "pdfa response is a valid PDF"
+  else
+    fail "pdfa response is not a valid PDF (magic bytes: $MAGIC)"
+  fi
+  rm -f "$TMP_PDFA"
+
+  echo ""
+else
+  echo "--- POST /pdf/pdfa (skipped — GHOSTSCRIPT_PATH not set) ---"
+  echo ""
+fi
+
 # ── DELETE /pdf/:id ───────────────────────────────────────────────────────────
 
 echo "--- DELETE /pdf/:id ---"

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -11,6 +11,7 @@ const envSchema = z.object({
   LOG_LEVEL: z.enum(['trace', 'debug', 'info', 'warn', 'error']).default('info'),
   PORT: z.coerce.number().int().positive().default(8080),
   API_KEY: z.string().min(32).optional(),
+  GHOSTSCRIPT_PATH: z.string().optional(),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/routes/pdf/handler.ts
+++ b/src/routes/pdf/handler.ts
@@ -1,9 +1,17 @@
 import type { FastifyReply, FastifyRequest } from 'fastify';
 import { PDFDocument } from 'pdf-lib';
-import type { GenerateRequestInput, PdfIdParams, MergeRequestInput } from './schema.js';
+import type {
+  GenerateRequestInput,
+  PdfIdParams,
+  MergeRequestInput,
+  SplitRequestInput,
+  CompressRequestInput,
+  PdfARequestInput,
+} from './schema.js';
 import type { PdfService } from '../../services/pdf/PdfService.js';
 import type { StorageService } from '../../services/storage/StorageService.js';
 import type { MetricsService } from '../../services/metrics/MetricsService.js';
+import type { PdfOperationsService } from '../../services/pdf/PdfOperationsService.js';
 
 export function createGetHandler(storageService: StorageService) {
   return async function getHandler(
@@ -52,6 +60,63 @@ export function createMergeHandler(storageService: StorageService) {
     }
 
     const url = await storageService.upload(mergedBuffer);
+    return reply.send({ statusCode: 200, data: { url } });
+  };
+}
+
+export function createSplitHandler(storageService: StorageService, opsService: PdfOperationsService) {
+  return async function splitHandler(
+    request: FastifyRequest<{ Body: SplitRequestInput }>,
+    reply: FastifyReply,
+  ) {
+    const { id, pages, stream } = request.body;
+    const sourceBytes = await storageService.download(id);
+    const resultBuffer = await opsService.split(sourceBytes, pages);
+    if (stream) {
+      return reply
+        .header('Content-Type', 'application/pdf')
+        .header('Content-Disposition', 'attachment; filename="split.pdf"')
+        .send(resultBuffer);
+    }
+    const url = await storageService.upload(resultBuffer);
+    return reply.send({ statusCode: 200, data: { url } });
+  };
+}
+
+export function createCompressHandler(storageService: StorageService, opsService: PdfOperationsService) {
+  return async function compressHandler(
+    request: FastifyRequest<{ Body: CompressRequestInput }>,
+    reply: FastifyReply,
+  ) {
+    const { id, stream } = request.body;
+    const sourceBytes = await storageService.download(id);
+    const resultBuffer = await opsService.compress(sourceBytes);
+    if (stream) {
+      return reply
+        .header('Content-Type', 'application/pdf')
+        .header('Content-Disposition', 'attachment; filename="compressed.pdf"')
+        .send(resultBuffer);
+    }
+    const url = await storageService.upload(resultBuffer);
+    return reply.send({ statusCode: 200, data: { url } });
+  };
+}
+
+export function createPdfAHandler(storageService: StorageService, opsService: PdfOperationsService) {
+  return async function pdfAHandler(
+    request: FastifyRequest<{ Body: PdfARequestInput }>,
+    reply: FastifyReply,
+  ) {
+    const { id, conformance, stream } = request.body;
+    const sourceBytes = await storageService.download(id);
+    const resultBuffer = await opsService.convertToPdfA(sourceBytes, conformance);
+    if (stream) {
+      return reply
+        .header('Content-Type', 'application/pdf')
+        .header('Content-Disposition', 'attachment; filename="pdfa.pdf"')
+        .send(resultBuffer);
+    }
+    const url = await storageService.upload(resultBuffer);
     return reply.send({ statusCode: 200, data: { url } });
   };
 }

--- a/src/routes/pdf/index.ts
+++ b/src/routes/pdf/index.ts
@@ -3,26 +3,34 @@ import {
   generateRequestJsonSchema,
   pdfIdParamsJsonSchema,
   mergeRequestJsonSchema,
+  splitRequestJsonSchema,
+  compressRequestJsonSchema,
+  pdfARequestJsonSchema,
 } from './schema.js';
 import {
   createGenerateHandler,
   createGetHandler,
   createDeleteHandler,
   createMergeHandler,
+  createSplitHandler,
+  createCompressHandler,
+  createPdfAHandler,
 } from './handler.js';
 import type { PdfService } from '../../services/pdf/PdfService.js';
 import type { StorageService } from '../../services/storage/StorageService.js';
 import type { MetricsService } from '../../services/metrics/MetricsService.js';
+import type { PdfOperationsService } from '../../services/pdf/PdfOperationsService.js';
 
 interface PdfRouteOptions {
   pdfService: PdfService;
   storageService: StorageService;
   metricsService: MetricsService;
+  opsService: PdfOperationsService;
 }
 
 export const pdfRoutes: FastifyPluginAsync<PdfRouteOptions> = async (
   fastify,
-  { pdfService, storageService, metricsService },
+  { pdfService, storageService, metricsService, opsService },
 ) => {
   fastify.post('/pdf/generate', {
     schema: {
@@ -45,4 +53,21 @@ export const pdfRoutes: FastifyPluginAsync<PdfRouteOptions> = async (
     schema: { body: mergeRequestJsonSchema },
     handler: createMergeHandler(storageService),
   });
+
+  fastify.post('/pdf/split', {
+    schema: { body: splitRequestJsonSchema },
+    handler: createSplitHandler(storageService, opsService),
+  });
+
+  fastify.post('/pdf/compress', {
+    schema: { body: compressRequestJsonSchema },
+    handler: createCompressHandler(storageService, opsService),
+  });
+
+  if (opsService.canUseGhostscript) {
+    fastify.post('/pdf/pdfa', {
+      schema: { body: pdfARequestJsonSchema },
+      handler: createPdfAHandler(storageService, opsService),
+    });
+  }
 };

--- a/src/routes/pdf/schema.ts
+++ b/src/routes/pdf/schema.ts
@@ -51,3 +51,32 @@ export type MergeRequestInput = z.infer<typeof mergeRequestSchema>;
 
 const { $schema: _s2, ...mergeRequestJsonSchema } = z.toJSONSchema(mergeRequestSchema);
 export { mergeRequestJsonSchema };
+
+export const splitRequestSchema = z.object({
+  id: z.string().uuid(),
+  pages: z.string().min(1),
+  stream: z.boolean().optional().default(false),
+});
+export type SplitRequestInput = z.infer<typeof splitRequestSchema>;
+
+const { $schema: _s3, ...splitRequestJsonSchema } = z.toJSONSchema(splitRequestSchema);
+export { splitRequestJsonSchema };
+
+export const compressRequestSchema = z.object({
+  id: z.string().uuid(),
+  stream: z.boolean().optional().default(false),
+});
+export type CompressRequestInput = z.infer<typeof compressRequestSchema>;
+
+const { $schema: _s4, ...compressRequestJsonSchema } = z.toJSONSchema(compressRequestSchema);
+export { compressRequestJsonSchema };
+
+export const pdfARequestSchema = z.object({
+  id: z.string().uuid(),
+  conformance: z.enum(['1b', '2b', '3b']).optional().default('2b'),
+  stream: z.boolean().optional().default(false),
+});
+export type PdfARequestInput = z.infer<typeof pdfARequestSchema>;
+
+const { $schema: _s5, ...pdfARequestJsonSchema } = z.toJSONSchema(pdfARequestSchema);
+export { pdfARequestJsonSchema };

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { healthRoutes } from './routes/health/index.js';
 import { pdfRoutes } from './routes/pdf/index.js';
 import { metricsRoutes } from './routes/metrics/index.js';
 import { PdfService } from './services/pdf/PdfService.js';
+import { PdfOperationsService } from './services/pdf/PdfOperationsService.js';
 import { StorageService } from './services/storage/StorageService.js';
 import { MetricsService } from './services/metrics/MetricsService.js';
 
@@ -23,6 +24,7 @@ export async function buildApp() {
 
   const pdfService = new PdfService();
   const metricsService = new MetricsService();
+  const opsService = new PdfOperationsService(env.GHOSTSCRIPT_PATH);
 
   await fastify.register(sensiblePlugin);
   await fastify.register(authPlugin);
@@ -32,6 +34,7 @@ export async function buildApp() {
     pdfService,
     storageService: new StorageService(fastify.s3, fastify.s3Public),
     metricsService,
+    opsService,
   });
   await fastify.register(metricsRoutes, { metricsService });
 

--- a/src/services/pdf/PdfOperationsService.test.ts
+++ b/src/services/pdf/PdfOperationsService.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { PDFDocument } from 'pdf-lib';
+import { parsePageRange, PdfOperationsService } from './PdfOperationsService.js';
+
+vi.mock('child_process', () => ({ spawn: vi.fn() }));
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  readFile: vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 compressed')),
+  unlink: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { spawn } from 'child_process';
+
+function makeGsProcess(exitCode = 0) {
+  const proc = new EventEmitter() as NodeJS.EventEmitter & { stderr: NodeJS.EventEmitter };
+  (proc as any).stderr = new EventEmitter();
+  setImmediate(() => proc.emit('close', exitCode));
+  return proc;
+}
+
+async function makePdf(pageCount = 3): Promise<Buffer> {
+  const doc = await PDFDocument.create();
+  for (let i = 0; i < pageCount; i++) doc.addPage();
+  return Buffer.from(await doc.save());
+}
+
+describe('parsePageRange', () => {
+  it('parses a single page', () => {
+    expect(parsePageRange('2', 5)).toEqual([1]);
+  });
+
+  it('parses a range', () => {
+    expect(parsePageRange('1-3', 5)).toEqual([0, 1, 2]);
+  });
+
+  it('parses a comma list', () => {
+    expect(parsePageRange('1,3,5', 5)).toEqual([0, 2, 4]);
+  });
+
+  it('parses an open-ended range', () => {
+    expect(parsePageRange('3-', 5)).toEqual([2, 3, 4]);
+  });
+
+  it('clamps out-of-range indices', () => {
+    expect(parsePageRange('1-10', 3)).toEqual([0, 1, 2]);
+  });
+
+  it('deduplicates overlapping selections', () => {
+    expect(parsePageRange('1-3,2-4', 5)).toEqual([0, 1, 2, 3]);
+  });
+});
+
+describe('PdfOperationsService', () => {
+  let service: PdfOperationsService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new PdfOperationsService();
+  });
+
+  describe('split', () => {
+    it('extracts specified pages', async () => {
+      const source = await makePdf(5);
+      const result = await service.split(source, '1,3,5');
+      const doc = await PDFDocument.load(result);
+      expect(doc.getPageCount()).toBe(3);
+    });
+
+    it('handles open-ended range', async () => {
+      const source = await makePdf(4);
+      const result = await service.split(source, '2-');
+      const doc = await PDFDocument.load(result);
+      expect(doc.getPageCount()).toBe(3);
+    });
+
+    it('throws when page range produces no pages', async () => {
+      const source = await makePdf(3);
+      await expect(service.split(source, '5')).rejects.toThrow('Page range produces no pages');
+    });
+  });
+
+  describe('compress (pdf-lib fallback)', () => {
+    it('returns a buffer when Ghostscript is not configured', async () => {
+      const source = await makePdf(1);
+      const result = await service.compress(source);
+      expect(result).toBeInstanceOf(Buffer);
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('compress (Ghostscript)', () => {
+    beforeEach(() => {
+      service = new PdfOperationsService('/usr/bin/gs');
+      vi.mocked(spawn).mockReturnValue(makeGsProcess(0) as any);
+    });
+
+    it('calls Ghostscript with compress args', async () => {
+      const source = await makePdf(1);
+      const result = await service.compress(source);
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/bin/gs',
+        expect.arrayContaining(['-dPDFSETTINGS=/ebook', '-sDEVICE=pdfwrite']),
+      );
+      expect(result).toBeInstanceOf(Buffer);
+    });
+
+    it('throws when Ghostscript exits with non-zero code', async () => {
+      vi.mocked(spawn).mockReturnValue(makeGsProcess(1) as any);
+      const source = await makePdf(1);
+      await expect(service.compress(source)).rejects.toThrow('Ghostscript exited with code 1');
+    });
+  });
+
+  describe('convertToPdfA', () => {
+    it('throws when Ghostscript is not configured', async () => {
+      const source = await makePdf(1);
+      await expect(service.convertToPdfA(source)).rejects.toThrow('Ghostscript is required');
+    });
+
+    it('calls Ghostscript with PDF/A args', async () => {
+      service = new PdfOperationsService('/usr/bin/gs');
+      vi.mocked(spawn).mockReturnValue(makeGsProcess(0) as any);
+      const source = await makePdf(1);
+      await service.convertToPdfA(source, '2b');
+      expect(spawn).toHaveBeenCalledWith(
+        '/usr/bin/gs',
+        expect.arrayContaining(['-dPDFA=2', '-sDEVICE=pdfwrite']),
+      );
+    });
+
+    it('uses the correct PDF/A level for each conformance', async () => {
+      service = new PdfOperationsService('/usr/bin/gs');
+      for (const [conf, level] of [['1b', 1], ['2b', 2], ['3b', 3]] as const) {
+        vi.mocked(spawn).mockReturnValue(makeGsProcess(0) as any);
+        const source = await makePdf(1);
+        await service.convertToPdfA(source, conf);
+        expect(spawn).toHaveBeenCalledWith(
+          '/usr/bin/gs',
+          expect.arrayContaining([`-dPDFA=${level}`]),
+        );
+        vi.clearAllMocks();
+      }
+    });
+  });
+
+  describe('canUseGhostscript', () => {
+    it('is false when no ghostscript path is set', () => {
+      expect(service.canUseGhostscript).toBe(false);
+    });
+
+    it('is true when ghostscript path is set', () => {
+      const gsService = new PdfOperationsService('/usr/bin/gs');
+      expect(gsService.canUseGhostscript).toBe(true);
+    });
+  });
+});

--- a/src/services/pdf/PdfOperationsService.ts
+++ b/src/services/pdf/PdfOperationsService.ts
@@ -1,0 +1,125 @@
+import { PDFDocument } from 'pdf-lib';
+import { spawn } from 'child_process';
+import { writeFile, readFile, unlink } from 'fs/promises';
+import { join } from 'path';
+import { randomUUID } from 'crypto';
+import { tmpdir } from 'os';
+
+export function parsePageRange(expr: string, totalPages: number): number[] {
+  const indices: number[] = [];
+  for (const part of expr.split(',')) {
+    const trimmed = part.trim();
+    if (trimmed.includes('-')) {
+      const [start, end] = trimmed.split('-');
+      const from = start ? parseInt(start, 10) - 1 : 0;
+      const to = end ? parseInt(end, 10) - 1 : totalPages - 1;
+      for (let i = from; i <= to; i++) indices.push(i);
+    } else {
+      indices.push(parseInt(trimmed, 10) - 1);
+    }
+  }
+  return [...new Set(indices)].filter((i) => i >= 0 && i < totalPages);
+}
+
+function runGhostscript(gsPath: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const gs = spawn(gsPath, args);
+    let stderr = '';
+    gs.stderr.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+    gs.on('close', (code: number | null) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Ghostscript exited with code ${code}: ${stderr}`));
+      }
+    });
+    gs.on('error', reject);
+  });
+}
+
+export class PdfOperationsService {
+  constructor(private readonly ghostscriptPath?: string) {}
+
+  get canUseGhostscript(): boolean {
+    return !!this.ghostscriptPath;
+  }
+
+  async split(sourceBytes: Buffer, pages: string): Promise<Buffer> {
+    const source = await PDFDocument.load(sourceBytes);
+    const totalPages = source.getPageCount();
+    const indices = parsePageRange(pages, totalPages);
+
+    if (indices.length === 0) {
+      throw new Error('Page range produces no pages');
+    }
+
+    const output = await PDFDocument.create();
+    const copied = await output.copyPages(source, indices);
+    copied.forEach((page) => output.addPage(page));
+    return Buffer.from(await output.save());
+  }
+
+  async compress(sourceBytes: Buffer): Promise<Buffer> {
+    if (this.ghostscriptPath) {
+      return this.ghostscriptCompress(sourceBytes);
+    }
+    // Fallback: re-save with object streams (compresses xref tables)
+    const doc = await PDFDocument.load(sourceBytes);
+    return Buffer.from(await doc.save({ useObjectStreams: true }));
+  }
+
+  async convertToPdfA(sourceBytes: Buffer, conformance: '1b' | '2b' | '3b' = '2b'): Promise<Buffer> {
+    if (!this.ghostscriptPath) {
+      throw new Error('Ghostscript is required for PDF/A conversion');
+    }
+    return this.ghostscriptPdfA(sourceBytes, conformance);
+  }
+
+  private async ghostscriptCompress(sourceBytes: Buffer): Promise<Buffer> {
+    const id = randomUUID();
+    const inPath = join(tmpdir(), `pdf-compress-in-${id}.pdf`);
+    const outPath = join(tmpdir(), `pdf-compress-out-${id}.pdf`);
+    try {
+      await writeFile(inPath, sourceBytes);
+      await runGhostscript(this.ghostscriptPath!, [
+        '-sDEVICE=pdfwrite',
+        '-dCompatibilityLevel=1.4',
+        '-dPDFSETTINGS=/ebook',
+        '-dNOPAUSE',
+        '-dQUIET',
+        '-dBATCH',
+        `-sOutputFile=${outPath}`,
+        inPath,
+      ]);
+      return await readFile(outPath);
+    } finally {
+      await Promise.allSettled([unlink(inPath), unlink(outPath)]);
+    }
+  }
+
+  private async ghostscriptPdfA(sourceBytes: Buffer, conformance: '1b' | '2b' | '3b'): Promise<Buffer> {
+    const levelMap: Record<string, number> = { '1b': 1, '2b': 2, '3b': 3 };
+    const level = levelMap[conformance];
+    const id = randomUUID();
+    const inPath = join(tmpdir(), `pdf-pdfa-in-${id}.pdf`);
+    const outPath = join(tmpdir(), `pdf-pdfa-out-${id}.pdf`);
+    try {
+      await writeFile(inPath, sourceBytes);
+      await runGhostscript(this.ghostscriptPath!, [
+        `-dPDFA=${level}`,
+        '-dBATCH',
+        '-dNOPAUSE',
+        '-sDEVICE=pdfwrite',
+        '-sColorConversionStrategy=UseDeviceIndependentColor',
+        '-dPDFACompatibilityPolicy=1',
+        `-sOutputFile=${outPath}`,
+        inPath,
+      ]);
+      return await readFile(outPath);
+    } finally {
+      await Promise.allSettled([unlink(inPath), unlink(outPath)]);
+    }
+  }
+}


### PR DESCRIPTION
- PdfOperationsService: split via pdf-lib, compress via Ghostscript (with pdf-lib fallback), PDF/A via Ghostscript
- Routes: POST /pdf/split (always), POST /pdf/compress (always), POST /pdf/pdfa (only when GHOSTSCRIPT_PATH is set)
- GHOSTSCRIPT_PATH env var added; ghostscript installed in Dockerfile
- Smoke test, README, and AGENTS.md updated

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>