### PR TITLE
Improve PDF API resilience and repo consistency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,3 +64,4 @@ jobs:
         run: ./scripts/smoke-test.sh "${{ needs.deploy.outputs.api-url }}"
         env:
           API_KEY: ${{ secrets.API_KEY }}
+          GHOSTSCRIPT_PATH: /usr/bin/gs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,6 @@ src/
     metrics/MetricsService.ts       # In-memory histograms + counter; serialises to Prometheus text
   types/
     index.ts                   # GenerateRequest, PaperOptions, PdfOptions, GenerateResponse
-    aws-lambda-fastify.d.ts    # Ambient declaration for aws-lambda-fastify (no types shipped)
 ```
 
 ## Authentication
@@ -69,7 +68,7 @@ Returns service liveness. Also responds to `HEAD /health`.
 { "status": "ok" }
 ```
 
-Use for load balancer health checks or Lambda function URL probes. No auth required.
+Use for load balancer health checks or Lambda function URL probes. Requires `X-Api-Key` when `API_KEY` is set.
 
 **Files:** `src/routes/health/index.ts`, `src/routes/health/handler.ts`
 
@@ -112,7 +111,7 @@ Metrics are in-memory (reset on restart). `MetricsService` is instantiated in `s
 
 **Response (`stream: false`):**
 ```json
-{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+{ "statusCode": 200, "data": { "id": "550e8400-e29b-41d4-a716-446655440000", "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
 ```
 
 **Response (`stream: true`):**
@@ -160,12 +159,12 @@ Downloads two or more existing PDFs by their IDs, merges them in page order usin
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `ids` | UUID[] | yes | Ordered list of PDF IDs (minimum 2) |
+| `ids` | UUID[] | yes | Ordered list of PDF IDs (minimum 2, maximum 20) |
 | `stream` | boolean | no | `true` = binary, `false` = S3 URL (default) |
 
 **Response (`stream: false`):**
 ```json
-{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+{ "statusCode": 200, "data": { "id": "550e8400-e29b-41d4-a716-446655440000", "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
 ```
 
 **Response (`stream: true`):** `Content-Type: application/pdf`, `Content-Disposition: attachment; filename="merged.pdf"`, binary PDF bytes.
@@ -195,7 +194,7 @@ Extracts a subset of pages from an existing PDF using `pdf-lib`.
 | `pages` | string | yes | Page range expression: `"1-3"` (range), `"1,3,5"` (comma list), `"2-"` (open-ended) |
 | `stream` | boolean | no | `true` = binary, `false` = S3 URL (default) |
 
-Page numbers are 1-based. Ranges are inclusive. Out-of-range indices are silently dropped. Duplicates are deduplicated. Returns `500` if the expression yields no valid pages.
+Page numbers are 1-based. Ranges are inclusive. Out-of-range indices are silently dropped. Duplicates are deduplicated. Invalid expressions or expressions that yield no valid pages return `400`.
 
 **Files:** `src/routes/pdf/handler.ts` (`createSplitHandler`), `src/services/pdf/PdfOperationsService.ts` (`split`, `parsePageRange`)
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The same container image runs on **AWS Lambda** or plain **Docker** without modi
 | Screenshot (PNG/JPEG) | Planned | ✅ |
 | DOCX / XLSX → PDF | Planned (Docker only) | ✅ |
 | PDF merge | ✅ | ✅ |
-| PDF split / compress | Planned | ✅ |
+| PDF split / compress / PDF/A | ✅ | ✅ |
 | Prometheus metrics | ✅ | ✅ |
 | Language | TypeScript | Go |
 
@@ -116,7 +116,7 @@ Render HTML to PDF with headless Chromium.
 **Response — S3 URL**
 
 ```json
-{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+{ "statusCode": 200, "data": { "id": "550e8400-e29b-41d4-a716-446655440000", "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
 ```
 
 **Response — binary stream**
@@ -163,13 +163,13 @@ Merge two or more existing PDFs (by their IDs) into one document.
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `ids` | UUID[] | yes | Ordered list of PDF IDs to merge (minimum 2) |
+| `ids` | UUID[] | yes | Ordered list of PDF IDs to merge (minimum 2, maximum 20) |
 | `stream` | boolean | no | `true` = binary response, `false` = S3 URL (default) |
 
 **Response — S3 URL (`stream: false`)**
 
 ```json
-{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+{ "statusCode": 200, "data": { "id": "550e8400-e29b-41d4-a716-446655440000", "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
 ```
 
 **Response — binary stream (`stream: true`)**
@@ -205,7 +205,7 @@ Extracts a subset of pages from an existing PDF.
 **Response — S3 URL (`stream: false`)**
 
 ```json
-{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+{ "statusCode": 200, "data": { "id": "550e8400-e29b-41d4-a716-446655440000", "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
 ```
 
 **Response — binary stream (`stream: true`)**
@@ -239,7 +239,7 @@ Reduces the file size of an existing PDF. Uses Ghostscript when `GHOSTSCRIPT_PAT
 **Response — S3 URL (`stream: false`)**
 
 ```json
-{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+{ "statusCode": 200, "data": { "id": "550e8400-e29b-41d4-a716-446655440000", "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
 ```
 
 **Response — binary stream (`stream: true`)**
@@ -275,7 +275,7 @@ Converts an existing PDF to PDF/A for long-term archival compliance. **Requires 
 **Response — S3 URL (`stream: false`)**
 
 ```json
-{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
+{ "statusCode": 200, "data": { "id": "550e8400-e29b-41d4-a716-446655440000", "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }
 ```
 
 **Response — binary stream (`stream: true`)**
@@ -406,7 +406,7 @@ src/
   routes/
     health/              # GET /health
     metrics/             # GET /metrics
-    pdf/                 # POST /pdf/generate, GET /pdf/:id, DELETE /pdf/:id, POST /pdf/merge
+    pdf/                 # POST /pdf/generate, GET/DELETE /pdf/:id, POST /pdf/merge, /pdf/split, /pdf/compress, /pdf/pdfa
   services/
     pdf/PdfService.ts               # Puppeteer browser lifecycle + PDF generation
     pdf/PdfOperationsService.ts     # split (pdf-lib), compress + PDF/A (Ghostscript / pdf-lib fallback)
@@ -414,7 +414,6 @@ src/
     metrics/MetricsService.ts       # In-memory Prometheus metrics (histograms + counters)
   types/
     index.ts                   # Shared TypeScript interfaces
-    aws-lambda-fastify.d.ts    # Ambient type declaration for aws-lambda-fastify
 
 test/integration/
   generate.test.ts       # Full route tests via app.inject() — no real browser
@@ -458,10 +457,10 @@ If deletion fails again, inspect the event log for the specific resource blockin
 
 ### Docker / ECS / Fly.io / Railway
 
-Build the `server` stage and run anywhere Docker is supported:
+Build the image and run anywhere Docker is supported:
 
 ```bash
-docker build --target server -t pdf-microservice .
+docker build -t pdf-microservice .
 docker run -p 8080:8080 --env-file .env pdf-microservice
 ```
 
@@ -471,7 +470,7 @@ docker run -p 8080:8080 --env-file .env pdf-microservice
 
 See [`.plans/PLAN.md`](.plans/PLAN.md) for the full feature roadmap and Gotenberg comparison.
 
-Planned features (in order): URL rendering → Screenshot API → OpenAPI docs → LibreOffice conversion → PDF split/compress/PDF/A → Async webhooks → Queue-based scaling → Open-source publishing (GHCR image, release automation).
+Planned features (in order): URL rendering → Screenshot API → OpenAPI docs → LibreOffice conversion → Async webhooks → Queue-based scaling → Open-source publishing (GHCR image, release automation).
 
 ---
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -50,6 +50,11 @@ extract_id() {
   echo "$1" | sed 's|.*pdfs/\([^.]*\)\.pdf.*|\1|'
 }
 
+# extract a string field from a compact JSON response body
+extract_json_string() {
+  echo "$1" | sed -n "s|.*\"$2\":\"\\([^\"]*\\)\".*|\\1|p"
+}
+
 # Auth header args for curl — used as "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}" 
 # Must be an array; command substitution $(func) word-splits the header value.
 AUTH_HEADER=()
@@ -134,8 +139,7 @@ STATUS_CODE=$(echo "$RESP" | grep -o '"statusCode":[0-9]*' | grep -o '[0-9]*')
 assert_eq "statusCode 200" "200" "$STATUS_CODE"
 assert_contains "response contains url" '"url"' "$RESP"
 
-URL1=$(echo "$RESP" | sed 's/.*"url":"\([^"]*\)".*/\1/')
-ID1=$(extract_id "$URL1")
+ID1=$(extract_json_string "$RESP" id)
 echo "    ID 1: $ID1"
 
 echo ""
@@ -169,8 +173,7 @@ RESP2=$(curl -s -X POST "$BASE/pdf/generate" \
   "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
   -H "Content-Type: application/json" \
   -d '{"html": "<html><body><h1>Smoke Test Page 2</h1></body></html>"}')
-URL2=$(echo "$RESP2" | sed 's/.*"url":"\([^"]*\)".*/\1/')
-ID2=$(extract_id "$URL2")
+ID2=$(extract_json_string "$RESP2" id)
 assert_contains "second generate ok" '"statusCode":200' "$RESP2"
 echo "    ID 2: $ID2"
 

--- a/src/routes/pdf/handler.ts
+++ b/src/routes/pdf/handler.ts
@@ -9,9 +9,13 @@ import type {
   PdfARequestInput,
 } from './schema.js';
 import type { PdfService } from '../../services/pdf/PdfService.js';
-import type { StorageService } from '../../services/storage/StorageService.js';
+import type { StorageService, StoredPdf } from '../../services/storage/StorageService.js';
 import type { MetricsService } from '../../services/metrics/MetricsService.js';
 import type { PdfOperationsService } from '../../services/pdf/PdfOperationsService.js';
+
+function sendStoredPdf(reply: FastifyReply, storedPdf: StoredPdf) {
+  return reply.send({ statusCode: 200, data: storedPdf });
+}
 
 export function createGetHandler(storageService: StorageService) {
   return async function getHandler(
@@ -59,8 +63,8 @@ export function createMergeHandler(storageService: StorageService) {
         .send(mergedBuffer);
     }
 
-    const url = await storageService.upload(mergedBuffer);
-    return reply.send({ statusCode: 200, data: { url } });
+    const storedPdf = await storageService.upload(mergedBuffer);
+    return sendStoredPdf(reply, storedPdf);
   };
 }
 
@@ -78,8 +82,8 @@ export function createSplitHandler(storageService: StorageService, opsService: P
         .header('Content-Disposition', 'attachment; filename="split.pdf"')
         .send(resultBuffer);
     }
-    const url = await storageService.upload(resultBuffer);
-    return reply.send({ statusCode: 200, data: { url } });
+    const storedPdf = await storageService.upload(resultBuffer);
+    return sendStoredPdf(reply, storedPdf);
   };
 }
 
@@ -97,8 +101,8 @@ export function createCompressHandler(storageService: StorageService, opsService
         .header('Content-Disposition', 'attachment; filename="compressed.pdf"')
         .send(resultBuffer);
     }
-    const url = await storageService.upload(resultBuffer);
-    return reply.send({ statusCode: 200, data: { url } });
+    const storedPdf = await storageService.upload(resultBuffer);
+    return sendStoredPdf(reply, storedPdf);
   };
 }
 
@@ -116,8 +120,8 @@ export function createPdfAHandler(storageService: StorageService, opsService: Pd
         .header('Content-Disposition', 'attachment; filename="pdfa.pdf"')
         .send(resultBuffer);
     }
-    const url = await storageService.upload(resultBuffer);
-    return reply.send({ statusCode: 200, data: { url } });
+    const storedPdf = await storageService.upload(resultBuffer);
+    return sendStoredPdf(reply, storedPdf);
   };
 }
 
@@ -131,29 +135,26 @@ export function createGenerateHandler(
     reply: FastifyReply,
   ) {
     const { html, css, paper, options, stream } = request.body;
-    
     const start = Date.now();
-    let pdfBuffer: Buffer;
+
     try {
-      pdfBuffer = await pdfService.generate(html, css, paper, options);
+      const pdfBuffer = await pdfService.generate(html, css, paper, options);
+
+      if (stream) {
+        metricsService.recordSuccess(Date.now() - start, pdfBuffer.length);
+        return reply
+          .header('Content-Type', 'application/pdf')
+          .header('Content-Disposition', 'attachment; filename="document.pdf"')
+          .send(pdfBuffer);
+      }
+
+      const storedPdf = await storageService.upload(pdfBuffer);
+      metricsService.recordSuccess(Date.now() - start, pdfBuffer.length);
+
+      return sendStoredPdf(reply, storedPdf);
     } catch (err) {
       metricsService.recordError();
       throw err;
     }
-    metricsService.recordSuccess(Date.now() - start, pdfBuffer.length);
-
-    if (stream) {
-      return reply
-        .header('Content-Type', 'application/pdf')
-        .header('Content-Disposition', 'attachment; filename="document.pdf"')
-        .send(pdfBuffer);
-    }
-
-    const url = await storageService.upload(pdfBuffer);
-
-    return reply.send({
-      statusCode: 200,
-      data: { url },
-    });
   };
 }

--- a/src/routes/pdf/schema.ts
+++ b/src/routes/pdf/schema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+export const MAX_MERGE_IDS = 20;
+
 export const generateRequestSchema = z.object({
   html: z.string().min(1, 'html is required'),
   css: z.string().optional(),
@@ -44,7 +46,7 @@ const { $schema: _s1, ...pdfIdParamsJsonSchema } = z.toJSONSchema(pdfIdParamsSch
 export { pdfIdParamsJsonSchema };
 
 export const mergeRequestSchema = z.object({
-  ids: z.array(z.string().uuid()).min(2),
+  ids: z.array(z.string().uuid()).min(2).max(MAX_MERGE_IDS),
   stream: z.boolean().optional().default(false),
 });
 export type MergeRequestInput = z.infer<typeof mergeRequestSchema>;

--- a/src/services/pdf/PdfOperationsService.test.ts
+++ b/src/services/pdf/PdfOperationsService.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EventEmitter } from 'events';
 import { PDFDocument } from 'pdf-lib';
-import { parsePageRange, PdfOperationsService } from './PdfOperationsService.js';
+import {
+  InvalidPageRangeError,
+  parsePageRange,
+  PdfOperationsService,
+} from './PdfOperationsService.js';
 
 vi.mock('child_process', () => ({ spawn: vi.fn() }));
 vi.mock('fs/promises', () => ({
@@ -12,9 +16,15 @@ vi.mock('fs/promises', () => ({
 
 import { spawn } from 'child_process';
 
-function makeGsProcess(exitCode = 0) {
-  const proc = new EventEmitter() as NodeJS.EventEmitter & { stderr: NodeJS.EventEmitter };
-  (proc as any).stderr = new EventEmitter();
+type MockGsProcess = EventEmitter & { stderr: EventEmitter };
+
+function asSpawnReturn(proc: MockGsProcess): ReturnType<typeof spawn> {
+  return proc as unknown as ReturnType<typeof spawn>;
+}
+
+function makeGsProcess(exitCode = 0): MockGsProcess {
+  const proc = new EventEmitter() as MockGsProcess;
+  proc.stderr = new EventEmitter();
   setImmediate(() => proc.emit('close', exitCode));
   return proc;
 }
@@ -49,6 +59,18 @@ describe('parsePageRange', () => {
   it('deduplicates overlapping selections', () => {
     expect(parsePageRange('1-3,2-4', 5)).toEqual([0, 1, 2, 3]);
   });
+
+  it('throws for non-numeric segments', () => {
+    expect(() => parsePageRange('1,abc', 5)).toThrow(InvalidPageRangeError);
+  });
+
+  it('throws for descending ranges', () => {
+    expect(() => parsePageRange('3-1', 5)).toThrow('Page range cannot be descending');
+  });
+
+  it('throws for empty segments', () => {
+    expect(() => parsePageRange('1,,2', 5)).toThrow('Page range contains an empty segment');
+  });
 });
 
 describe('PdfOperationsService', () => {
@@ -76,7 +98,12 @@ describe('PdfOperationsService', () => {
 
     it('throws when page range produces no pages', async () => {
       const source = await makePdf(3);
-      await expect(service.split(source, '5')).rejects.toThrow('Page range produces no pages');
+      await expect(service.split(source, '5')).rejects.toThrow(InvalidPageRangeError);
+    });
+
+    it('throws when page range syntax is invalid', async () => {
+      const source = await makePdf(3);
+      await expect(service.split(source, 'abc')).rejects.toThrow(InvalidPageRangeError);
     });
   });
 
@@ -92,7 +119,7 @@ describe('PdfOperationsService', () => {
   describe('compress (Ghostscript)', () => {
     beforeEach(() => {
       service = new PdfOperationsService('/usr/bin/gs');
-      vi.mocked(spawn).mockReturnValue(makeGsProcess(0) as any);
+      vi.mocked(spawn).mockReturnValue(asSpawnReturn(makeGsProcess(0)));
     });
 
     it('calls Ghostscript with compress args', async () => {
@@ -106,7 +133,7 @@ describe('PdfOperationsService', () => {
     });
 
     it('throws when Ghostscript exits with non-zero code', async () => {
-      vi.mocked(spawn).mockReturnValue(makeGsProcess(1) as any);
+      vi.mocked(spawn).mockReturnValue(asSpawnReturn(makeGsProcess(1)));
       const source = await makePdf(1);
       await expect(service.compress(source)).rejects.toThrow('Ghostscript exited with code 1');
     });
@@ -120,7 +147,7 @@ describe('PdfOperationsService', () => {
 
     it('calls Ghostscript with PDF/A args', async () => {
       service = new PdfOperationsService('/usr/bin/gs');
-      vi.mocked(spawn).mockReturnValue(makeGsProcess(0) as any);
+      vi.mocked(spawn).mockReturnValue(asSpawnReturn(makeGsProcess(0)));
       const source = await makePdf(1);
       await service.convertToPdfA(source, '2b');
       expect(spawn).toHaveBeenCalledWith(
@@ -132,7 +159,7 @@ describe('PdfOperationsService', () => {
     it('uses the correct PDF/A level for each conformance', async () => {
       service = new PdfOperationsService('/usr/bin/gs');
       for (const [conf, level] of [['1b', 1], ['2b', 2], ['3b', 3]] as const) {
-        vi.mocked(spawn).mockReturnValue(makeGsProcess(0) as any);
+        vi.mocked(spawn).mockReturnValue(asSpawnReturn(makeGsProcess(0)));
         const source = await makePdf(1);
         await service.convertToPdfA(source, conf);
         expect(spawn).toHaveBeenCalledWith(

--- a/src/services/pdf/PdfOperationsService.ts
+++ b/src/services/pdf/PdfOperationsService.ts
@@ -5,20 +5,70 @@ import { join } from 'path';
 import { randomUUID } from 'crypto';
 import { tmpdir } from 'os';
 
+export class InvalidPageRangeError extends Error {
+  readonly statusCode = 400;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidPageRangeError';
+  }
+}
+
+function parsePositivePageNumber(value: string, part: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw new InvalidPageRangeError(`Invalid page range segment: "${part}"`);
+  }
+
+  const pageNumber = Number(value);
+  if (pageNumber < 1) {
+    throw new InvalidPageRangeError(`Page numbers must be greater than zero: "${part}"`);
+  }
+
+  return pageNumber;
+}
+
 export function parsePageRange(expr: string, totalPages: number): number[] {
+  const uniqueIndices = new Set<number>();
   const indices: number[] = [];
-  for (const part of expr.split(',')) {
-    const trimmed = part.trim();
-    if (trimmed.includes('-')) {
-      const [start, end] = trimmed.split('-');
-      const from = start ? parseInt(start, 10) - 1 : 0;
-      const to = end ? parseInt(end, 10) - 1 : totalPages - 1;
-      for (let i = from; i <= to; i++) indices.push(i);
-    } else {
-      indices.push(parseInt(trimmed, 10) - 1);
+
+  for (const segment of expr.split(',')) {
+    const part = segment.trim();
+    if (!part) {
+      throw new InvalidPageRangeError('Page range contains an empty segment');
+    }
+
+    const rangeMatch = /^(\d+)?-(\d+)?$/.exec(part);
+    if (rangeMatch) {
+      const [, startText, endText] = rangeMatch;
+      if (!startText && !endText) {
+        throw new InvalidPageRangeError(`Invalid page range segment: "${part}"`);
+      }
+
+      const from = startText ? parsePositivePageNumber(startText, part) - 1 : 0;
+      const to = endText ? parsePositivePageNumber(endText, part) - 1 : totalPages - 1;
+
+      if (from > to) {
+        throw new InvalidPageRangeError(`Page range cannot be descending: "${part}"`);
+      }
+
+      for (let i = from; i <= to; i++) {
+        if (i >= 0 && i < totalPages && !uniqueIndices.has(i)) {
+          uniqueIndices.add(i);
+          indices.push(i);
+        }
+      }
+
+      continue;
+    }
+
+    const index = parsePositivePageNumber(part, part) - 1;
+    if (index >= 0 && index < totalPages && !uniqueIndices.has(index)) {
+      uniqueIndices.add(index);
+      indices.push(index);
     }
   }
-  return [...new Set(indices)].filter((i) => i >= 0 && i < totalPages);
+
+  return indices;
 }
 
 function runGhostscript(gsPath: string, args: string[]): Promise<void> {
@@ -52,7 +102,7 @@ export class PdfOperationsService {
     const indices = parsePageRange(pages, totalPages);
 
     if (indices.length === 0) {
-      throw new Error('Page range produces no pages');
+      throw new InvalidPageRangeError('Page range produces no pages');
     }
 
     const output = await PDFDocument.create();

--- a/src/services/pdf/PdfService.test.ts
+++ b/src/services/pdf/PdfService.test.ts
@@ -128,4 +128,17 @@ describe('PdfService', () => {
 
     expect(mockBrowserClose).toHaveBeenCalledOnce();
   });
+
+  it('retries browser launch after an initial launch failure', async () => {
+    mockLaunch
+      .mockRejectedValueOnce(new Error('Chromium failed to start'))
+      .mockResolvedValueOnce({
+        newPage: mockNewPage,
+        close: mockBrowserClose,
+      });
+
+    await expect(pdfService.generate('<html></html>')).rejects.toThrow('Chromium failed to start');
+    await expect(pdfService.generate('<html></html>')).resolves.toBeInstanceOf(Buffer);
+    expect(mockLaunch).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/services/pdf/PdfService.ts
+++ b/src/services/pdf/PdfService.ts
@@ -14,7 +14,10 @@ export class PdfService {
 
   async getBrowser(): Promise<Browser> {
     if (!this.browserPromise) {
-      this.browserPromise = this._launch();
+      this.browserPromise = this._launch().catch((err: unknown) => {
+        this.browserPromise = null;
+        throw err;
+      });
     }
     return this.browserPromise;
   }
@@ -88,9 +91,12 @@ export class PdfService {
   }
 
   async close(): Promise<void> {
-    if (this.browserPromise) {
-      const browser = await this.browserPromise;
-      this.browserPromise = null;
+    const browserPromise = this.browserPromise;
+    this.browserPromise = null;
+
+    if (browserPromise) {
+      const browser = await browserPromise.catch(() => null);
+      if (!browser) return;
       await browser.close();
     }
   }

--- a/src/services/storage/StorageService.test.ts
+++ b/src/services/storage/StorageService.test.ts
@@ -40,9 +40,12 @@ describe('StorageService', () => {
   it('uploads PDF and returns a presigned URL', async () => {
     const pdfBuffer = Buffer.from('%PDF-1.4 test content');
 
-    const url = await storageService.upload(pdfBuffer);
+    const storedPdf = await storageService.upload(pdfBuffer);
 
-    expect(url).toBe('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+    expect(storedPdf).toMatchObject({
+      id: expect.any(String),
+      url: 'https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true',
+    });
     expect(mockS3Client.send).toHaveBeenCalledOnce();
   });
 
@@ -54,5 +57,23 @@ describe('StorageService', () => {
 
     const sendCall = vi.mocked(mockS3Client.send).mock.calls[0][0];
     expect(sendCall).toBeInstanceOf(PutObjectCommand);
+  });
+
+  it('checks that a PDF exists before presigning its URL', async () => {
+    const { HeadObjectCommand } = await import('@aws-sdk/client-s3');
+
+    await storageService.getUrl('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+
+    const sendCall = vi.mocked(mockS3Client.send).mock.calls[0][0];
+    expect(sendCall).toBeInstanceOf(HeadObjectCommand);
+  });
+
+  it('throws a not found error when the PDF does not exist', async () => {
+    const notFoundError = Object.assign(new Error('missing'), { name: 'NotFound' });
+    vi.mocked(mockS3Client.send).mockRejectedValueOnce(notFoundError);
+
+    await expect(storageService.getUrl('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')).rejects.toThrow(
+      'PDF not found',
+    );
   });
 });

--- a/src/services/storage/StorageService.ts
+++ b/src/services/storage/StorageService.ts
@@ -3,10 +3,33 @@ import {
   PutObjectCommand,
   GetObjectCommand,
   DeleteObjectCommand,
+  HeadObjectCommand,
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { randomUUID } from 'crypto';
 import { env } from '../../config/env.js';
+
+export interface StoredPdf {
+  id: string;
+  url: string;
+}
+
+export class PdfNotFoundError extends Error {
+  readonly statusCode = 404;
+
+  constructor(id: string) {
+    super(`PDF not found: ${id}`);
+    this.name = 'PdfNotFoundError';
+  }
+}
+
+function isS3NotFoundError(err: unknown): boolean {
+  if (!(err instanceof Error)) {
+    return false;
+  }
+
+  return err.name === 'NoSuchKey' || err.name === 'NotFound';
+}
 
 export class StorageService {
   // s3 is used for uploads; s3Public is used for presigning so the returned
@@ -20,7 +43,23 @@ export class StorageService {
     return `pdfs/${id}.pdf`;
   }
 
+  private async assertExists(id: string): Promise<void> {
+    try {
+      await this.s3.send(
+        new HeadObjectCommand({ Bucket: env.S3_BUCKET, Key: this.keyFromId(id) }),
+      );
+    } catch (err) {
+      if (isS3NotFoundError(err)) {
+        throw new PdfNotFoundError(id);
+      }
+
+      throw err;
+    }
+  }
+
   async getUrl(id: string): Promise<string> {
+    await this.assertExists(id);
+
     return getSignedUrl(
       this.s3Public,
       new GetObjectCommand({ Bucket: env.S3_BUCKET, Key: this.keyFromId(id) }),
@@ -35,15 +74,30 @@ export class StorageService {
   }
 
   async download(id: string): Promise<Buffer> {
-    const response = await this.s3.send(
-      new GetObjectCommand({ Bucket: env.S3_BUCKET, Key: this.keyFromId(id) }),
-    );
-    const bytes = await response.Body!.transformToByteArray();
+    let response;
+    try {
+      response = await this.s3.send(
+        new GetObjectCommand({ Bucket: env.S3_BUCKET, Key: this.keyFromId(id) }),
+      );
+    } catch (err) {
+      if (isS3NotFoundError(err)) {
+        throw new PdfNotFoundError(id);
+      }
+
+      throw err;
+    }
+
+    if (!response.Body) {
+      throw new PdfNotFoundError(id);
+    }
+
+    const bytes = await response.Body.transformToByteArray();
     return Buffer.from(bytes);
   }
 
-  async upload(pdfBuffer: Buffer): Promise<string> {
-    const key = `pdfs/${randomUUID()}.pdf`;
+  async upload(pdfBuffer: Buffer): Promise<StoredPdf> {
+    const id = randomUUID();
+    const key = this.keyFromId(id);
 
     await this.s3.send(
       new PutObjectCommand({
@@ -63,6 +117,6 @@ export class StorageService {
       { expiresIn: env.SIGNED_URL_EXPIRY_SECONDS },
     );
 
-    return url;
+    return { id, url };
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,7 @@ export interface GenerateRequest {
 export interface GenerateResponse {
   statusCode: number;
   data: {
+    id: string;
     url: string;
   };
 }

--- a/test/integration/auth.test.ts
+++ b/test/integration/auth.test.ts
@@ -24,7 +24,10 @@ vi.mock('../../src/services/pdf/PdfService.js', () => ({
 
 vi.mock('../../src/services/storage/StorageService.js', () => ({
   StorageService: class {
-    upload = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+    upload = vi.fn().mockResolvedValue({
+      id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      url: 'https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true',
+    });
   },
 }));
 

--- a/test/integration/compress.test.ts
+++ b/test/integration/compress.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { PDFDocument } from 'pdf-lib';
 import type { FastifyInstance } from 'fastify';
-import { MAX_MERGE_IDS } from '../../src/routes/pdf/schema.js';
+
+const STORED_PDF = {
+  id: '6ee48e67-f825-40e4-8be0-8cc4c1dfd637',
+  url: 'https://s3.amazonaws.com/test-bucket/pdfs/compressed.pdf?signed=true',
+};
+const SOURCE_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+const MISSING_ID = '0f7f4b24-fb7d-4f7b-a94d-a673d2f6ef83';
+
+let sourcePdfBuffer: Buffer;
 
 vi.mock('../../src/config/env.js', () => ({
   env: {
@@ -21,18 +29,18 @@ vi.mock('../../src/services/pdf/PdfService.js', () => ({
   },
 }));
 
-// Provide a real minimal PDF buffer so pdf-lib can load it during the merge
-let minimalPdfBuffer: Buffer;
-
 vi.mock('../../src/services/storage/StorageService.js', () => ({
   StorageService: class {
-    upload = vi.fn().mockResolvedValue({
-      id: 'c2cf6b63-9bd4-4be1-8577-048ca0ddde3c',
-      url: 'https://s3.amazonaws.com/test-bucket/pdfs/merged.pdf?signed=true',
-    });
+    upload = vi.fn().mockResolvedValue(STORED_PDF);
     getUrl = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
     delete = vi.fn().mockResolvedValue(undefined);
-    download = vi.fn().mockImplementation(() => Promise.resolve(minimalPdfBuffer));
+    download = vi.fn().mockImplementation(async (id: string) => {
+      if (id === MISSING_ID) {
+        throw Object.assign(new Error(`PDF not found: ${id}`), { statusCode: 404 });
+      }
+
+      return sourcePdfBuffer;
+    });
   },
 }));
 
@@ -43,16 +51,13 @@ vi.mock('../../src/plugins/s3.js', () => ({
   },
 }));
 
-const UUID1 = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
-const UUID2 = 'b1ffcd00-0d1c-4f09-8c7e-7cc0ce491b22';
-
-describe('POST /pdf/merge', () => {
+describe('POST /pdf/compress', () => {
   let app: FastifyInstance;
 
   beforeAll(async () => {
     const doc = await PDFDocument.create();
     doc.addPage();
-    minimalPdfBuffer = Buffer.from(await doc.save());
+    sourcePdfBuffer = Buffer.from(await doc.save());
 
     const { buildApp } = await import('../../src/server.js');
     app = await buildApp();
@@ -63,64 +68,39 @@ describe('POST /pdf/merge', () => {
     await app.close();
   });
 
-  it('returns a presigned URL when stream is false', async () => {
+  it('returns a stored PDF response when stream is false', async () => {
     const response = await app.inject({
       method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids: [UUID1, UUID2] },
+      url: '/pdf/compress',
+      payload: { id: SOURCE_ID },
     });
 
     expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body).toMatchObject({
+    expect(response.json()).toMatchObject({
       statusCode: 200,
-      data: {
-        id: expect.any(String),
-        url: expect.stringContaining('https://'),
-      },
+      data: STORED_PDF,
     });
   });
 
   it('returns binary PDF when stream is true', async () => {
     const response = await app.inject({
       method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids: [UUID1, UUID2], stream: true },
+      url: '/pdf/compress',
+      payload: { id: SOURCE_ID, stream: true },
     });
 
     expect(response.statusCode).toBe(200);
     expect(response.headers['content-type']).toContain('application/pdf');
   });
 
-  it('returns 400 when fewer than 2 IDs are provided', async () => {
+  it('returns 404 when the source PDF does not exist', async () => {
     const response = await app.inject({
       method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids: [UUID1] },
+      url: '/pdf/compress',
+      payload: { id: MISSING_ID },
     });
 
-    expect(response.statusCode).toBe(400);
-  });
-
-  it('returns 400 for non-UUID ids', async () => {
-    const response = await app.inject({
-      method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids: ['not-a-uuid', 'also-not-a-uuid'] },
-    });
-
-    expect(response.statusCode).toBe(400);
-  });
-
-  it('returns 400 when too many IDs are provided', async () => {
-    const ids = Array.from({ length: MAX_MERGE_IDS + 1 }, () => UUID1);
-
-    const response = await app.inject({
-      method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids },
-    });
-
-    expect(response.statusCode).toBe(400);
+    expect(response.statusCode).toBe(404);
+    expect(response.json().message).toContain('PDF not found');
   });
 });

--- a/test/integration/delete.test.ts
+++ b/test/integration/delete.test.ts
@@ -21,7 +21,10 @@ vi.mock('../../src/services/pdf/PdfService.js', () => ({
 
 vi.mock('../../src/services/storage/StorageService.js', () => ({
   StorageService: class {
-    upload = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+    upload = vi.fn().mockResolvedValue({
+      id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      url: 'https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true',
+    });
     getUrl = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
     delete = vi.fn().mockResolvedValue(undefined);
     download = vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 test'));

--- a/test/integration/generate.test.ts
+++ b/test/integration/generate.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 
+const STORED_PDF = {
+  id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+  url: 'https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true',
+};
+
 // Mock env before importing server
 vi.mock('../../src/config/env.js', () => ({
   env: {
@@ -24,7 +29,7 @@ vi.mock('../../src/services/pdf/PdfService.js', () => ({
 // Mock StorageService
 vi.mock('../../src/services/storage/StorageService.js', () => ({
   StorageService: class {
-    upload = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+    upload = vi.fn().mockResolvedValue(STORED_PDF);
   },
 }));
 
@@ -62,7 +67,7 @@ describe('POST /pdf/generate', () => {
     const body = response.json();
     expect(body).toMatchObject({
       statusCode: 200,
-      data: { url: expect.stringContaining('https://') },
+      data: STORED_PDF,
     });
   });
 

--- a/test/integration/get.test.ts
+++ b/test/integration/get.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 
+const VALID_UUID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+const MISSING_UUID = '0f7f4b24-fb7d-4f7b-a94d-a673d2f6ef83';
+
 vi.mock('../../src/config/env.js', () => ({
   env: {
     S3_BUCKET: 'test-bucket',
@@ -21,8 +24,17 @@ vi.mock('../../src/services/pdf/PdfService.js', () => ({
 
 vi.mock('../../src/services/storage/StorageService.js', () => ({
   StorageService: class {
-    upload = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
-    getUrl = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+    upload = vi.fn().mockResolvedValue({
+      id: VALID_UUID,
+      url: 'https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true',
+    });
+    getUrl = vi.fn().mockImplementation(async (id: string) => {
+      if (id === MISSING_UUID) {
+        throw Object.assign(new Error(`PDF not found: ${id}`), { statusCode: 404 });
+      }
+
+      return 'https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true';
+    });
     delete = vi.fn().mockResolvedValue(undefined);
     download = vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 test'));
   },
@@ -34,8 +46,6 @@ vi.mock('../../src/plugins/s3.js', () => ({
     fastify.decorate('s3Public', {});
   },
 }));
-
-const VALID_UUID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
 
 describe('GET /pdf/:id', () => {
   let app: FastifyInstance;
@@ -71,5 +81,15 @@ describe('GET /pdf/:id', () => {
     });
 
     expect(response.statusCode).toBe(400);
+  });
+
+  it('returns 404 when the PDF does not exist', async () => {
+    const response = await app.inject({
+      method: 'GET',
+      url: `/pdf/${MISSING_UUID}`,
+    });
+
+    expect(response.statusCode).toBe(404);
+    expect(response.json().message).toContain('PDF not found');
   });
 });

--- a/test/integration/health.test.ts
+++ b/test/integration/health.test.ts
@@ -26,7 +26,10 @@ vi.mock('../../src/services/storage/StorageService.js', () => ({
   StorageService: class {
     upload = vi
       .fn()
-      .mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+      .mockResolvedValue({
+        id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+        url: 'https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true',
+      });
   },
 }));
 

--- a/test/integration/metrics.test.ts
+++ b/test/integration/metrics.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { FastifyInstance } from 'fastify';
+
+const uploadMock = vi.fn().mockResolvedValue({
+  id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+  url: 'https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true',
+});
 
 vi.mock('../../src/config/env.js', () => ({
   env: {
@@ -21,7 +26,7 @@ vi.mock('../../src/services/pdf/PdfService.js', () => ({
 
 vi.mock('../../src/services/storage/StorageService.js', () => ({
   StorageService: class {
-    upload = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
+    upload = uploadMock;
   },
 }));
 
@@ -35,13 +40,18 @@ vi.mock('../../src/plugins/s3.js', () => ({
 describe('GET /metrics', () => {
   let app: FastifyInstance;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     const { buildApp } = await import('../../src/server.js');
     app = await buildApp();
     await app.ready();
+    uploadMock.mockReset();
+    uploadMock.mockResolvedValue({
+      id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+      url: 'https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true',
+    });
   });
 
-  afterAll(async () => {
+  afterEach(async () => {
     await app.close();
   });
 
@@ -76,5 +86,25 @@ describe('GET /metrics', () => {
     expect(body).toContain('pdf_size_bytes_bucket{le="10240"} 0');
     expect(body).toContain('pdf_size_bytes_bucket{le="51200"} 1');
     expect(body).toContain('pdf_size_bytes_count 1');
+  });
+
+  it('counts upload failures as errors instead of successes', async () => {
+    uploadMock.mockRejectedValueOnce(new Error('S3 upload failed'));
+
+    const generateResponse = await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      payload: { html: '<html><body>hello</body></html>' },
+    });
+
+    expect(generateResponse.statusCode).toBe(500);
+
+    const response = await app.inject({ method: 'GET', url: '/metrics' });
+    const body = response.body;
+
+    expect(body).toContain('pdf_generation_requests_total{status="success"} 0');
+    expect(body).toContain('pdf_generation_requests_total{status="error"} 1');
+    expect(body).toContain('pdf_generation_duration_ms_count 0');
+    expect(body).toContain('pdf_size_bytes_count 0');
   });
 });

--- a/test/integration/pdfa.test.ts
+++ b/test/integration/pdfa.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
-import { PDFDocument } from 'pdf-lib';
 import type { FastifyInstance } from 'fastify';
-import { MAX_MERGE_IDS } from '../../src/routes/pdf/schema.js';
+
+const STORED_PDF = {
+  id: '4aa737ee-e6e7-4f17-b455-cc0ec0d54bb1',
+  url: 'https://s3.amazonaws.com/test-bucket/pdfs/pdfa.pdf?signed=true',
+};
+const SOURCE_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+const MISSING_ID = '0f7f4b24-fb7d-4f7b-a94d-a673d2f6ef83';
 
 vi.mock('../../src/config/env.js', () => ({
   env: {
@@ -10,6 +15,7 @@ vi.mock('../../src/config/env.js', () => ({
     SIGNED_URL_EXPIRY_SECONDS: 3600,
     LOG_LEVEL: 'error',
     PORT: 8080,
+    GHOSTSCRIPT_PATH: '/usr/bin/gs',
   },
 }));
 
@@ -21,18 +27,32 @@ vi.mock('../../src/services/pdf/PdfService.js', () => ({
   },
 }));
 
-// Provide a real minimal PDF buffer so pdf-lib can load it during the merge
-let minimalPdfBuffer: Buffer;
+vi.mock('../../src/services/pdf/PdfOperationsService.js', () => ({
+  PdfOperationsService: class {
+    constructor(_ghostscriptPath?: string) {}
+
+    get canUseGhostscript() {
+      return true;
+    }
+
+    split = vi.fn();
+    compress = vi.fn();
+    convertToPdfA = vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 pdfa'));
+  },
+}));
 
 vi.mock('../../src/services/storage/StorageService.js', () => ({
   StorageService: class {
-    upload = vi.fn().mockResolvedValue({
-      id: 'c2cf6b63-9bd4-4be1-8577-048ca0ddde3c',
-      url: 'https://s3.amazonaws.com/test-bucket/pdfs/merged.pdf?signed=true',
-    });
+    upload = vi.fn().mockResolvedValue(STORED_PDF);
     getUrl = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
     delete = vi.fn().mockResolvedValue(undefined);
-    download = vi.fn().mockImplementation(() => Promise.resolve(minimalPdfBuffer));
+    download = vi.fn().mockImplementation(async (id: string) => {
+      if (id === MISSING_ID) {
+        throw Object.assign(new Error(`PDF not found: ${id}`), { statusCode: 404 });
+      }
+
+      return Buffer.from('%PDF-1.4 source');
+    });
   },
 }));
 
@@ -43,17 +63,10 @@ vi.mock('../../src/plugins/s3.js', () => ({
   },
 }));
 
-const UUID1 = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
-const UUID2 = 'b1ffcd00-0d1c-4f09-8c7e-7cc0ce491b22';
-
-describe('POST /pdf/merge', () => {
+describe('POST /pdf/pdfa', () => {
   let app: FastifyInstance;
 
   beforeAll(async () => {
-    const doc = await PDFDocument.create();
-    doc.addPage();
-    minimalPdfBuffer = Buffer.from(await doc.save());
-
     const { buildApp } = await import('../../src/server.js');
     app = await buildApp();
     await app.ready();
@@ -63,64 +76,49 @@ describe('POST /pdf/merge', () => {
     await app.close();
   });
 
-  it('returns a presigned URL when stream is false', async () => {
+  it('returns a stored PDF response when stream is false', async () => {
     const response = await app.inject({
       method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids: [UUID1, UUID2] },
+      url: '/pdf/pdfa',
+      payload: { id: SOURCE_ID, conformance: '2b' },
     });
 
     expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body).toMatchObject({
+    expect(response.json()).toMatchObject({
       statusCode: 200,
-      data: {
-        id: expect.any(String),
-        url: expect.stringContaining('https://'),
-      },
+      data: STORED_PDF,
     });
   });
 
   it('returns binary PDF when stream is true', async () => {
     const response = await app.inject({
       method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids: [UUID1, UUID2], stream: true },
+      url: '/pdf/pdfa',
+      payload: { id: SOURCE_ID, conformance: '2b', stream: true },
     });
 
     expect(response.statusCode).toBe(200);
     expect(response.headers['content-type']).toContain('application/pdf');
   });
 
-  it('returns 400 when fewer than 2 IDs are provided', async () => {
+  it('returns 400 for an invalid conformance level', async () => {
     const response = await app.inject({
       method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids: [UUID1] },
+      url: '/pdf/pdfa',
+      payload: { id: SOURCE_ID, conformance: '9z' },
     });
 
     expect(response.statusCode).toBe(400);
   });
 
-  it('returns 400 for non-UUID ids', async () => {
+  it('returns 404 when the source PDF does not exist', async () => {
     const response = await app.inject({
       method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids: ['not-a-uuid', 'also-not-a-uuid'] },
+      url: '/pdf/pdfa',
+      payload: { id: MISSING_ID, conformance: '2b' },
     });
 
-    expect(response.statusCode).toBe(400);
-  });
-
-  it('returns 400 when too many IDs are provided', async () => {
-    const ids = Array.from({ length: MAX_MERGE_IDS + 1 }, () => UUID1);
-
-    const response = await app.inject({
-      method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids },
-    });
-
-    expect(response.statusCode).toBe(400);
+    expect(response.statusCode).toBe(404);
+    expect(response.json().message).toContain('PDF not found');
   });
 });

--- a/test/integration/split.test.ts
+++ b/test/integration/split.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
 import { PDFDocument } from 'pdf-lib';
 import type { FastifyInstance } from 'fastify';
-import { MAX_MERGE_IDS } from '../../src/routes/pdf/schema.js';
+
+const STORED_PDF = {
+  id: '7af4aadc-9811-4392-ac73-adfe0acb6b2a',
+  url: 'https://s3.amazonaws.com/test-bucket/pdfs/split.pdf?signed=true',
+};
+const SOURCE_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
+const MISSING_ID = '0f7f4b24-fb7d-4f7b-a94d-a673d2f6ef83';
+
+let sourcePdfBuffer: Buffer;
 
 vi.mock('../../src/config/env.js', () => ({
   env: {
@@ -21,18 +29,18 @@ vi.mock('../../src/services/pdf/PdfService.js', () => ({
   },
 }));
 
-// Provide a real minimal PDF buffer so pdf-lib can load it during the merge
-let minimalPdfBuffer: Buffer;
-
 vi.mock('../../src/services/storage/StorageService.js', () => ({
   StorageService: class {
-    upload = vi.fn().mockResolvedValue({
-      id: 'c2cf6b63-9bd4-4be1-8577-048ca0ddde3c',
-      url: 'https://s3.amazonaws.com/test-bucket/pdfs/merged.pdf?signed=true',
-    });
+    upload = vi.fn().mockResolvedValue(STORED_PDF);
     getUrl = vi.fn().mockResolvedValue('https://s3.amazonaws.com/test-bucket/pdfs/test.pdf?signed=true');
     delete = vi.fn().mockResolvedValue(undefined);
-    download = vi.fn().mockImplementation(() => Promise.resolve(minimalPdfBuffer));
+    download = vi.fn().mockImplementation(async (id: string) => {
+      if (id === MISSING_ID) {
+        throw Object.assign(new Error(`PDF not found: ${id}`), { statusCode: 404 });
+      }
+
+      return sourcePdfBuffer;
+    });
   },
 }));
 
@@ -43,16 +51,15 @@ vi.mock('../../src/plugins/s3.js', () => ({
   },
 }));
 
-const UUID1 = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11';
-const UUID2 = 'b1ffcd00-0d1c-4f09-8c7e-7cc0ce491b22';
-
-describe('POST /pdf/merge', () => {
+describe('POST /pdf/split', () => {
   let app: FastifyInstance;
 
   beforeAll(async () => {
     const doc = await PDFDocument.create();
     doc.addPage();
-    minimalPdfBuffer = Buffer.from(await doc.save());
+    doc.addPage();
+    doc.addPage();
+    sourcePdfBuffer = Buffer.from(await doc.save());
 
     const { buildApp } = await import('../../src/server.js');
     app = await buildApp();
@@ -63,64 +70,61 @@ describe('POST /pdf/merge', () => {
     await app.close();
   });
 
-  it('returns a presigned URL when stream is false', async () => {
+  it('returns a stored PDF response when stream is false', async () => {
     const response = await app.inject({
       method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids: [UUID1, UUID2] },
+      url: '/pdf/split',
+      payload: { id: SOURCE_ID, pages: '1-2' },
     });
 
     expect(response.statusCode).toBe(200);
-    const body = response.json();
-    expect(body).toMatchObject({
+    expect(response.json()).toMatchObject({
       statusCode: 200,
-      data: {
-        id: expect.any(String),
-        url: expect.stringContaining('https://'),
-      },
+      data: STORED_PDF,
     });
   });
 
   it('returns binary PDF when stream is true', async () => {
     const response = await app.inject({
       method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids: [UUID1, UUID2], stream: true },
+      url: '/pdf/split',
+      payload: { id: SOURCE_ID, pages: '2-', stream: true },
     });
 
     expect(response.statusCode).toBe(200);
     expect(response.headers['content-type']).toContain('application/pdf');
   });
 
-  it('returns 400 when fewer than 2 IDs are provided', async () => {
+  it('returns 400 for invalid page range syntax', async () => {
     const response = await app.inject({
       method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids: [UUID1] },
+      url: '/pdf/split',
+      payload: { id: SOURCE_ID, pages: 'abc' },
     });
 
     expect(response.statusCode).toBe(400);
+    expect(response.json().message).toContain('Invalid page range');
   });
 
-  it('returns 400 for non-UUID ids', async () => {
+  it('returns 400 when the page range produces no pages', async () => {
     const response = await app.inject({
       method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids: ['not-a-uuid', 'also-not-a-uuid'] },
+      url: '/pdf/split',
+      payload: { id: SOURCE_ID, pages: '99' },
     });
 
     expect(response.statusCode).toBe(400);
+    expect(response.json().message).toContain('Page range produces no pages');
   });
 
-  it('returns 400 when too many IDs are provided', async () => {
-    const ids = Array.from({ length: MAX_MERGE_IDS + 1 }, () => UUID1);
-
+  it('returns 404 when the source PDF does not exist', async () => {
     const response = await app.inject({
       method: 'POST',
-      url: '/pdf/merge',
-      payload: { ids },
+      url: '/pdf/split',
+      payload: { id: MISSING_ID, pages: '1' },
     });
 
-    expect(response.statusCode).toBe(400);
+    expect(response.statusCode).toBe(404);
+    expect(response.json().message).toContain('PDF not found');
   });
 });


### PR DESCRIPTION
## Summary

This PR hardens the PDF generation/storage flow, improves API error semantics, expands test coverage for PDF operations, and aligns the docs and deploy smoke tests with the current implementation.

## What changed

- Reset the cached Chromium browser promise after launch failures so the service can recover on the next request instead of requiring a restart.
- Record PDF generation success metrics only after the full request path succeeds, so failed uploads are counted as errors rather than successes.
- Return `404` for missing PDFs from storage operations instead of surfacing raw S3 errors.
- Treat invalid `/pdf/split` page-range inputs as `400` client errors.
- Return `{ id, url }` for non-stream stored PDF responses.
- Add a max merge input limit of 20 PDF IDs to reduce memory risk on `/pdf/merge`.
- Add integration coverage for `/pdf/split`, `/pdf/compress`, `/pdf/pdfa`, upload-failure metrics, missing PDFs, and invalid range handling.
- Update the README, AGENTS guidance, roadmap notes, smoke test, and deploy workflow so they match the current API and actually exercise PDF/A in deployment smoke tests.

## API note

Non-stream responses that create a new stored PDF now return:

```json
{
  "statusCode": 200,
  "data": {
    "id": "uuid",
    "url": "https://..."
  }
}
```

This applies to:
- `POST /pdf/generate`
- `POST /pdf/merge`
- `POST /pdf/split`
- `POST /pdf/compress`
- `POST /pdf/pdfa`

## Testing

- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run build`