### PR TITLE
add open source publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,4 +54,4 @@ jobs:
         with:
           context: .
           push: false
-          tags: pdf-microservice:ci
+          tags: folio:ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: Publish Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (standard image)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Extract metadata (full image)
+        id: meta-full
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}-full
+            type=semver,pattern={{major}}.{{minor}}-full
+            type=raw,value=latest-full
+
+      - name: Build and push standard image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: server
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Build and push full image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          target: server-full
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta-full.outputs.tags }}
+          labels: ${{ steps.meta-full.outputs.labels }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,19 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: node
+          package-name: folio

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,6 +318,7 @@ Planned features are documented in `.plans/`. See [`.plans/PLAN.md`](.plans/PLAN
 | `observability.md` | `GET /health`, `GET /metrics`, PDF generation histograms |
 | `additional-routes.md` | `GET /pdf/:id`, `DELETE /pdf/:id`, `POST /pdf/merge` |
 | `pdf-operations.md` | `POST /pdf/split`, `/pdf/compress`, `/pdf/pdfa` |
+| `open-source-publishing.md` | MIT license, GHCR image publishing, release-please, CONTRIBUTING |
 
 ### Planned — Gotenberg feature parity
 
@@ -336,4 +337,3 @@ Planned features are documented in `.plans/`. See [`.plans/PLAN.md`](.plans/PLAN
 | `node-server-deployment.md` | ECS Fargate / Fly.io plain Node server Docker stage |
 | `async-webhook.md` | `202 Accepted` + webhook callback for slow jobs |
 | `queue-based-scaling.md` | SQS / BullMQ decoupled worker tier |
-| `open-source-publishing.md` | LICENSE, GHCR image publishing, release-please, CONTRIBUTING |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This file is managed by release-please.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Thanks for contributing to folio.
+
+## Local setup
+
+```bash
+npm install
+cp .env.example .env
+docker compose up
+```
+
+The API will be available at `http://localhost:8080` and MinIO at `http://localhost:9001`.
+
+## Checks
+
+Run these before opening a pull request:
+
+```bash
+npm test
+npm run typecheck
+npm run lint
+npm run build
+```
+
+Use `docker compose up` when you want the full local API + MinIO stack. Tests do not require a real browser or S3 account because those dependencies are mocked.
+
+## Commit messages
+
+This repo uses Conventional Commits so release-please can automate release PRs and changelog updates.
+
+Examples:
+
+- `feat(pdf): add html screenshot route`
+- `fix(storage): handle missing object keys`
+- `docs(readme): update ghcr pull instructions`
+
+## Pull requests
+
+- Branch from `main`.
+- Keep the PR focused on one change.
+- Make sure the checks above pass locally or explain any gaps.
+- Update docs when you change routes, environment variables, workflows, or deployment behavior.
+- Include request or response examples when you change the public API.
+
+## Adding a route
+
+Use the existing routes as reference implementations:
+
+- `src/routes/health/` is the smallest example.
+- `src/routes/pdf/` shows the full pattern with schema, handlers, and storage integration.
+
+For new routes:
+
+1. Add the route module under `src/routes/<name>/`.
+2. Keep validation close to the route, following the `schema.ts` pattern where needed.
+3. Register the route from `src/server.ts`.
+4. Add integration coverage under `test/integration/` with `app.inject()`.
+5. Update `README.md` and `AGENTS.md` if the public API or operational model changes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ COPY tsconfig.json .
 COPY src/ src/
 RUN npm run build
 
-# Stage 2: production (Lambda base image includes the Runtime Interface Emulator)
-FROM public.ecr.aws/lambda/nodejs:24
+# Stage 2: production image used by local Docker, Lambda deploys, and GHCR
+FROM public.ecr.aws/lambda/nodejs:24 AS server
 WORKDIR /var/task
 RUN dnf install -y \
       alsa-lib \
@@ -40,3 +40,8 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
 CMD ["dist/lambda.handler"]
+
+# Reserved for the larger Docker-only toolchain. Keeping this target stable now
+# lets the publish workflow ship predictable `-full` tags before LibreOffice
+# conversion lands.
+FROM server AS server-full

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # folio
 
+[![License: MIT](https://img.shields.io/github/license/alegerber/folio)](LICENSE)
+
 Serverless-native PDF API. HTML → PDF on AWS Lambda, S3-first. TypeScript, Fastify, headless Chromium.
 
 The same container image runs on **AWS Lambda** or plain **Docker** without modification. PDF bytes go straight to S3 — no shared filesystem, no ephemeral `/tmp` issues.
@@ -50,7 +52,19 @@ The GitHub Pages site is published from [`docs/`](docs/) and includes the full A
 
 - [Documentation landing page](docs/index.html)
 - [API reference](docs/api/index.html)
+- [Contributing guide](CONTRIBUTING.md)
 - [GitHub Pages workflow](.github/workflows/pages.yml)
+
+## Container images
+
+Prebuilt images are published to GitHub Container Registry from semver tags like `v1.2.3`.
+
+```bash
+docker pull ghcr.io/alegerber/folio:latest
+docker pull ghcr.io/alegerber/folio:latest-full
+```
+
+Each release publishes `latest`, `x.y.z`, and `x.y` tags. Matching `-full` tags are also published so downstream deploys can adopt the long-lived tag shape now; they currently mirror the main image until the larger Docker-only conversion toolchain lands.
 
 ## Local development
 
@@ -81,10 +95,6 @@ npm install
 # Requires real AWS credentials and S3_BUCKET set in your environment
 npm run dev
 ```
-
-## Scripts
-
----
 
 ## Authentication
 
@@ -226,8 +236,14 @@ If deletion fails again, inspect the event log for the specific resource blockin
 Build the image and run anywhere Docker is supported:
 
 ```bash
-docker build -t pdf-microservice .
-docker run -p 8080:8080 --env-file .env pdf-microservice
+docker build -t folio .
+docker run -p 8080:8080 --env-file .env folio
+```
+
+Published images are also available from GHCR:
+
+```bash
+docker run -p 8080:8080 --env-file .env ghcr.io/alegerber/folio:latest
 ```
 
 ---
@@ -236,7 +252,7 @@ docker run -p 8080:8080 --env-file .env pdf-microservice
 
 See [`.plans/PLAN.md`](.plans/PLAN.md) for the full feature roadmap.
 
-Planned features (in order): URL rendering → Screenshot API → OpenAPI docs → LibreOffice conversion → Async webhooks → Queue-based scaling → Open-source publishing (GHCR image, release automation).
+Release automation and GHCR publishing are in place. Planned features (in order): URL rendering → Screenshot API → OpenAPI docs → LibreOffice conversion → Async webhooks → Queue-based scaling.
 
 ---
 
@@ -253,3 +269,11 @@ Planned features (in order): URL rendering → Screenshot API → OpenAPI docs �
 | Testing | Vitest | 4.x |
 | Build | esbuild | 0.27.x |
 | Runtime | Node.js | 24 |
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local setup, Conventional Commits, PR expectations, and route patterns.
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "pdf-microservice",
+  "name": "folio",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "pdf-microservice",
+      "name": "folio",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,16 @@
 {
-  "name": "pdf-microservice",
+  "name": "folio",
   "version": "1.0.0",
   "description": "PDF generation microservice using Puppeteer, Fastify, and S3",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/alegerber/folio.git"
+  },
+  "bugs": {
+    "url": "https://github.com/alegerber/folio/issues"
+  },
+  "homepage": "https://github.com/alegerber/folio#readme",
   "main": "dist/local.js",
   "scripts": {
     "build": "esbuild src/local.ts src/lambda.ts --bundle --platform=node --target=node24 --outdir=dist --external:@sparticuz/chromium --external:pino --external:pino-pretty --format=cjs",


### PR DESCRIPTION
Adds the open-source publishing foundation for folio.

This PR introduces GHCR image publishing and release-please workflows, adds CONTRIBUTING.md and CHANGELOG.md, fills in OSS metadata in package.json, and updates the README with license and container publish docs. It also names Docker build targets as server and server-full so the publish workflow can build both variants consistently.