### PR TITLE
feat: add URL rendering to POST /pdf/generate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,9 @@ Metrics are in-memory (reset on restart). `MetricsService` is instantiated in `s
 
 ### POST /pdf/generate
 
-**Request body:**
+Accepts either `html` (raw HTML string) or `url` (navigates to the URL and renders the page). The two fields are mutually exclusive.
+
+**Request body (HTML):**
 ```json
 {
   "html": "<html>...</html>",
@@ -105,6 +107,17 @@ Metrics are in-memory (reset on restart). `MetricsService` is instantiated in `s
     "headerTemplate": "<div style=\"font-size:10px;\">Header</div>",
     "footerTemplate": "<div style=\"font-size:10px;\">Page <span class=\"pageNumber\"></span></div>"
   },
+  "stream": false
+}
+```
+
+**Request body (URL):**
+```json
+{
+  "url": "https://example.com",
+  "cookies": [{ "name": "session", "value": "abc123", "domain": "example.com" }],
+  "extraHeaders": { "Authorization": "Bearer token" },
+  "paper": { "size": "A4" },
   "stream": false
 }
 ```
@@ -319,13 +332,13 @@ Planned features are documented in `.plans/`. See [`.plans/PLAN.md`](.plans/PLAN
 | `additional-routes.md` | `GET /pdf/:id`, `DELETE /pdf/:id`, `POST /pdf/merge` |
 | `pdf-operations.md` | `POST /pdf/split`, `/pdf/compress`, `/pdf/pdfa` |
 | `open-source-publishing.md` | MIT license, GHCR image publishing, release-please, CONTRIBUTING |
+| `url-rendering.md` | Render a URL instead of raw HTML, with cookies and extra headers |
 
 ### Planned — Gotenberg feature parity
 
 | File | Description |
 |---|---|
 | `ssrf-protection.md` | Shared SSRF guard for URL-accepting endpoints |
-| `url-rendering.md` | Render a URL instead of raw HTML |
 | `screenshot-api.md` | `POST /screenshot` — HTML/URL → PNG/JPEG/WebP |
 | `libreoffice-conversion.md` | `POST /convert` — DOCX/XLSX/PPTX → PDF via LibreOffice (Docker/ECS only) |
 | `openapi-docs.md` | `GET /docs` Swagger UI + `GET /openapi.json` |

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Folio is built for teams already on AWS who want a PDF service that fits their e
 - S3 upload plus presigned URL responses
 - API key authentication
 - HTML to PDF generation with CSS, headers, and footers
+- URL rendering — navigate to a URL and render the page as PDF (supports cookies and custom headers)
 - PDF merge, split, compress, and PDF/A routes
 - Prometheus-style metrics
-- Planned URL rendering, screenshots, OpenAPI docs, and document conversion
+- Planned screenshots, OpenAPI docs, and document conversion
 
 ---
 
@@ -252,7 +253,7 @@ docker run -p 8080:8080 --env-file .env ghcr.io/alegerber/folio:latest
 
 See [`.plans/PLAN.md`](.plans/PLAN.md) for the full feature roadmap.
 
-Release automation and GHCR publishing are in place. Planned features (in order): URL rendering → Screenshot API → OpenAPI docs → LibreOffice conversion → Async webhooks → Queue-based scaling.
+Release automation and GHCR publishing are in place. Planned features (in order): Screenshot API → OpenAPI docs → LibreOffice conversion → Async webhooks → Queue-based scaling.
 
 ---
 

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -334,6 +334,99 @@ else
   echo ""
 fi
 
+# ── POST /pdf/generate with url field ────────────────────────────────────────
+
+echo "--- POST /pdf/generate (url, stream: false) ---"
+RESP=$(curl -s -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}')
+
+STATUS_CODE=$(echo "$RESP" | grep -o '"statusCode":[0-9]*' | grep -o '[0-9]*')
+assert_eq "statusCode 200" "200" "$STATUS_CODE"
+assert_contains "response contains url" '"url"' "$RESP"
+
+URL_ID=$(extract_json_string "$RESP" id)
+echo "    URL ID: $URL_ID"
+
+echo ""
+
+# ── POST /pdf/generate with url + cookies/headers ───────────────────────────
+
+echo "--- POST /pdf/generate (url + cookies + extraHeaders) ---"
+RESP=$(curl -s -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com",
+    "cookies": [{"name": "test", "value": "abc", "domain": "example.com"}],
+    "extraHeaders": {"X-Custom": "smoke"}
+  }')
+STATUS_CODE=$(echo "$RESP" | grep -o '"statusCode":[0-9]*' | grep -o '[0-9]*')
+assert_eq "statusCode 200" "200" "$STATUS_CODE"
+
+echo ""
+
+# ── POST /pdf/generate with url (stream: true) ──────────────────────────────
+
+echo "--- POST /pdf/generate (url, stream: true) ---"
+TMP_URL_PDF=$(mktemp /tmp/smoke-test-url-XXXXXX.pdf)
+HTTP_CODE=$(curl -s -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com", "stream": true}' \
+  -o "$TMP_URL_PDF" -w "%{http_code}")
+assert_eq "HTTP 200" "200" "$HTTP_CODE"
+
+MAGIC=$(head -c 4 "$TMP_URL_PDF" 2>/dev/null || true)
+if [ "$MAGIC" = "%PDF" ]; then
+  ok "url response is a valid PDF"
+else
+  fail "url response is not a valid PDF (magic bytes: $MAGIC)"
+fi
+rm -f "$TMP_URL_PDF"
+
+echo ""
+
+# ── POST /pdf/generate validation: both html + url → 400 ────────────────────
+
+echo "--- POST /pdf/generate (html + url → 400) ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"html": "<h1>test</h1>", "url": "https://example.com"}')
+assert_eq "HTTP 400" "400" "$HTTP_CODE"
+
+echo ""
+
+# ── POST /pdf/generate validation: neither html nor url → 400 ───────────────
+
+echo "--- POST /pdf/generate (no html, no url → 400) ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{}')
+assert_eq "HTTP 400" "400" "$HTTP_CODE"
+
+echo ""
+
+# ── POST /pdf/generate validation: invalid url → 400 ────────────────────────
+
+echo "--- POST /pdf/generate (invalid url → 400) ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "not-a-url"}')
+assert_eq "HTTP 400" "400" "$HTTP_CODE"
+
+echo ""
+
+# ── Cleanup URL-generated PDF ────────────────────────────────────────────────
+
+if [ -n "$URL_ID" ]; then
+  curl -s -o /dev/null -X DELETE "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}" "$BASE/pdf/$URL_ID"
+fi
+
 # ── DELETE /pdf/:id ───────────────────────────────────────────────────────────
 
 echo "--- DELETE /pdf/:id ---"

--- a/src/routes/pdf/handler.ts
+++ b/src/routes/pdf/handler.ts
@@ -134,11 +134,19 @@ export function createGenerateHandler(
     request: FastifyRequest<{ Body: GenerateRequestInput }>,
     reply: FastifyReply,
   ) {
-    const { html, css, paper, options, stream } = request.body;
+    const { stream, ...generateInput } = request.body;
+
+    if (!generateInput.html && !generateInput.url) {
+      return reply.badRequest('Provide either html or url');
+    }
+    if (generateInput.html && generateInput.url) {
+      return reply.badRequest('Provide either html or url, not both');
+    }
+
     const start = Date.now();
 
     try {
-      const pdfBuffer = await pdfService.generate(html, css, paper, options);
+      const pdfBuffer = await pdfService.generate(generateInput);
 
       if (stream) {
         metricsService.recordSuccess(Date.now() - start, pdfBuffer.length);

--- a/src/routes/pdf/schema.ts
+++ b/src/routes/pdf/schema.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 export const MAX_MERGE_IDS = 20;
 
 export const generateRequestSchema = z.object({
-  html: z.string().min(1, 'html is required'),
+  html: z.string().min(1).optional(),
+  url: z.url().optional(),
   css: z.string().optional(),
   paper: z
     .object({
@@ -27,6 +28,16 @@ export const generateRequestSchema = z.object({
       footerTemplate: z.string().optional(),
     })
     .optional(),
+  cookies: z
+    .array(
+      z.object({
+        name: z.string(),
+        value: z.string(),
+        domain: z.string(),
+      }),
+    )
+    .optional(),
+  extraHeaders: z.record(z.string(), z.string()).optional(),
   stream: z.boolean().optional().default(false),
 });
 

--- a/src/services/pdf/PdfService.test.ts
+++ b/src/services/pdf/PdfService.test.ts
@@ -4,10 +4,16 @@ import { PdfService } from './PdfService.js';
 const mockPdf = vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 mock'));
 const mockClose = vi.fn().mockResolvedValue(undefined);
 const mockSetContent = vi.fn().mockResolvedValue(undefined);
+const mockGoto = vi.fn().mockResolvedValue(undefined);
 const mockAddStyleTag = vi.fn().mockResolvedValue(undefined);
+const mockSetCookie = vi.fn().mockResolvedValue(undefined);
+const mockSetExtraHTTPHeaders = vi.fn().mockResolvedValue(undefined);
 const mockNewPage = vi.fn().mockResolvedValue({
   setContent: mockSetContent,
+  goto: mockGoto,
   addStyleTag: mockAddStyleTag,
+  setCookie: mockSetCookie,
+  setExtraHTTPHeaders: mockSetExtraHTTPHeaders,
   pdf: mockPdf,
   close: mockClose,
 });
@@ -42,26 +48,61 @@ describe('PdfService', () => {
   it('generates a PDF from HTML', async () => {
     const html = '<html><body><h1>Hello World</h1></body></html>';
 
-    const result = await pdfService.generate(html);
+    const result = await pdfService.generate({ html });
 
     expect(mockSetContent).toHaveBeenCalledWith(html, { waitUntil: 'networkidle0' });
+    expect(mockGoto).not.toHaveBeenCalled();
     expect(mockAddStyleTag).not.toHaveBeenCalled();
     expect(mockPdf).toHaveBeenCalledOnce();
     expect(result).toBeInstanceOf(Buffer);
+  });
+
+  it('navigates to a URL when url is provided', async () => {
+    const url = 'https://example.com';
+
+    const result = await pdfService.generate({ url });
+
+    expect(mockGoto).toHaveBeenCalledWith(url, { waitUntil: 'networkidle0', timeout: 25_000 });
+    expect(mockSetContent).not.toHaveBeenCalled();
+    expect(mockPdf).toHaveBeenCalledOnce();
+    expect(result).toBeInstanceOf(Buffer);
+  });
+
+  it('sets cookies before navigation', async () => {
+    const cookies = [{ name: 'session', value: 'abc123', domain: 'example.com' }];
+
+    await pdfService.generate({ url: 'https://example.com', cookies });
+
+    expect(mockSetCookie).toHaveBeenCalledWith(...cookies);
+    // cookies set before goto
+    const setCookieOrder = mockSetCookie.mock.invocationCallOrder[0];
+    const gotoOrder = mockGoto.mock.invocationCallOrder[0];
+    expect(setCookieOrder).toBeLessThan(gotoOrder);
+  });
+
+  it('sets extra headers before navigation', async () => {
+    const extraHeaders = { Authorization: 'Bearer token123' };
+
+    await pdfService.generate({ url: 'https://example.com', extraHeaders });
+
+    expect(mockSetExtraHTTPHeaders).toHaveBeenCalledWith(extraHeaders);
+    const headersOrder = mockSetExtraHTTPHeaders.mock.invocationCallOrder[0];
+    const gotoOrder = mockGoto.mock.invocationCallOrder[0];
+    expect(headersOrder).toBeLessThan(gotoOrder);
   });
 
   it('injects CSS via addStyleTag when css is provided', async () => {
     const html = '<html><body><h1>Hello</h1></body></html>';
     const css = 'body { font-size: 14px; }';
 
-    await pdfService.generate(html, css);
+    await pdfService.generate({ html, css });
 
     expect(mockSetContent).toHaveBeenCalledWith(html, { waitUntil: 'networkidle0' });
     expect(mockAddStyleTag).toHaveBeenCalledWith({ content: css });
   });
 
   it('does not call addStyleTag when css is not provided', async () => {
-    await pdfService.generate('<html></html>');
+    await pdfService.generate({ html: '<html></html>' });
 
     expect(mockAddStyleTag).not.toHaveBeenCalled();
   });
@@ -69,7 +110,7 @@ describe('PdfService', () => {
   it('applies paper size options', async () => {
     const html = '<html><body></body></html>';
 
-    await pdfService.generate(html, undefined, { size: 'A4', orientation: 'portrait' });
+    await pdfService.generate({ html, paper: { size: 'A4', orientation: 'portrait' } });
 
     const pdfCall = mockPdf.mock.calls[0][0];
     expect(pdfCall).toMatchObject({ width: '210mm', height: '297mm' });
@@ -78,7 +119,7 @@ describe('PdfService', () => {
   it('applies landscape orientation by swapping dimensions', async () => {
     const html = '<html><body></body></html>';
 
-    await pdfService.generate(html, undefined, { size: 'A4', orientation: 'landscape' });
+    await pdfService.generate({ html, paper: { size: 'A4', orientation: 'landscape' } });
 
     const pdfCall = mockPdf.mock.calls[0][0];
     expect(pdfCall).toMatchObject({ width: '297mm', height: '210mm' });
@@ -87,16 +128,14 @@ describe('PdfService', () => {
   it('applies PDF options', async () => {
     const html = '<html><body></body></html>';
 
-    await pdfService.generate(
+    await pdfService.generate({
       html,
-      undefined,
-      undefined,
-      {
+      options: {
         printBackground: true,
         scale: 0.8,
         margin: { top: '10mm', bottom: '10mm', left: '15mm', right: '15mm' },
       },
-    );
+    });
 
     const pdfCall = mockPdf.mock.calls[0][0];
     expect(pdfCall).toMatchObject({
@@ -109,21 +148,21 @@ describe('PdfService', () => {
   it('closes the page after generation even on error', async () => {
     mockSetContent.mockRejectedValueOnce(new Error('Page load failed'));
 
-    await expect(pdfService.generate('<html></html>')).rejects.toThrow('Page load failed');
+    await expect(pdfService.generate({ html: '<html></html>' })).rejects.toThrow('Page load failed');
     expect(mockClose).toHaveBeenCalledOnce();
   });
 
   it('reuses the browser across multiple calls', async () => {
     const html = '<html><body></body></html>';
 
-    await pdfService.generate(html);
-    await pdfService.generate(html);
+    await pdfService.generate({ html });
+    await pdfService.generate({ html });
 
     expect(mockLaunch).toHaveBeenCalledOnce();
   });
 
   it('closes the browser on close()', async () => {
-    await pdfService.generate('<html></html>');
+    await pdfService.generate({ html: '<html></html>' });
     await pdfService.close();
 
     expect(mockBrowserClose).toHaveBeenCalledOnce();
@@ -137,8 +176,8 @@ describe('PdfService', () => {
         close: mockBrowserClose,
       });
 
-    await expect(pdfService.generate('<html></html>')).rejects.toThrow('Chromium failed to start');
-    await expect(pdfService.generate('<html></html>')).resolves.toBeInstanceOf(Buffer);
+    await expect(pdfService.generate({ html: '<html></html>' })).rejects.toThrow('Chromium failed to start');
+    await expect(pdfService.generate({ html: '<html></html>' })).resolves.toBeInstanceOf(Buffer);
     expect(mockLaunch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/services/pdf/PdfService.ts
+++ b/src/services/pdf/PdfService.ts
@@ -1,5 +1,15 @@
 import type { Browser, PaperFormat } from 'puppeteer-core';
-import type { PaperOptions, PdfOptions } from '../../types/index.js';
+import type { PaperOptions, PdfOptions, CookieParam } from '../../types/index.js';
+
+export interface GenerateInput {
+  html?: string;
+  url?: string;
+  css?: string;
+  paper?: PaperOptions;
+  options?: PdfOptions;
+  cookies?: CookieParam[];
+  extraHeaders?: Record<string, string>;
+}
 
 const PAPER_SIZES: Record<string, { width: string; height: string }> = {
   A4: { width: '210mm', height: '297mm' },
@@ -34,17 +44,24 @@ export class PdfService {
     });
   }
 
-  async generate(
-    html: string,
-    css?: string,
-    paper?: PaperOptions,
-    options?: PdfOptions,
-  ): Promise<Buffer> {
+  async generate(input: GenerateInput): Promise<Buffer> {
+    const { html, url, css, paper, options, cookies, extraHeaders } = input;
     const browser = await this.getBrowser();
     const page = await browser.newPage();
 
     try {
-      await page.setContent(html, { waitUntil: 'networkidle0' });
+      if (cookies?.length) {
+        await page.setCookie(...cookies);
+      }
+      if (extraHeaders) {
+        await page.setExtraHTTPHeaders(extraHeaders);
+      }
+
+      if (url) {
+        await page.goto(url, { waitUntil: 'networkidle0', timeout: 25_000 });
+      } else {
+        await page.setContent(html!, { waitUntil: 'networkidle0' });
+      }
 
       if (css) {
         await page.addStyleTag({ content: css });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,11 +18,20 @@ export interface PdfOptions {
   footerTemplate?: string;
 }
 
+export interface CookieParam {
+  name: string;
+  value: string;
+  domain: string;
+}
+
 export interface GenerateRequest {
-  html: string;
+  html?: string;
+  url?: string;
   css?: string;
   paper?: PaperOptions;
   options?: PdfOptions;
+  cookies?: CookieParam[];
+  extraHeaders?: Record<string, string>;
   stream?: boolean;
 }
 

--- a/test/integration/generate.test.ts
+++ b/test/integration/generate.test.ts
@@ -181,4 +181,60 @@ describe('POST /pdf/generate', () => {
 
     expect(response.statusCode).toBe(200);
   });
+
+  it('accepts a url field instead of html', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      payload: {
+        url: 'https://example.com',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toMatchObject({
+      statusCode: 200,
+      data: STORED_PDF,
+    });
+  });
+
+  it('accepts url with cookies and extraHeaders', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      payload: {
+        url: 'https://example.com',
+        cookies: [{ name: 'session', value: 'abc', domain: 'example.com' }],
+        extraHeaders: { Authorization: 'Bearer token' },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('returns 400 when both html and url are provided', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      payload: {
+        html: '<html></html>',
+        url: 'https://example.com',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid url', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      payload: {
+        url: 'not-a-url',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
 });


### PR DESCRIPTION
Accept a `url` field as an alternative to `html`. Puppeteer navigates to the URL and renders the page as PDF, supporting optional cookies and extra HTTP headers for authenticated pages.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>