### PR TITLE
docs: add curl examples and improve API reference layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ Thumbs.db
 .aws-sam
 samconfig.toml
 
+# Playwright 
+.playwright-mcp
 
 # Other
 output.pdf

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -78,6 +78,13 @@
           <div class="code-panel">
             <pre><code>{ "status": "ok" }</code></pre>
           </div>
+
+          <div class="example-block">
+            <span class="example-label">Example</span>
+            <div class="code-panel">
+              <pre><code>curl -s http://localhost:8080/health | jq .</code></pre>
+            </div>
+          </div>
         </section>
 
         <section id="metrics" class="endpoint-card">
@@ -86,6 +93,14 @@
             <code>/metrics</code>
           </div>
           <p>Returns Prometheus text-format metrics.</p>
+
+          <div class="example-block">
+            <span class="example-label">Example</span>
+            <div class="code-panel">
+              <pre><code>curl -s http://localhost:8080/metrics</code></pre>
+            </div>
+          </div>
+
           <table>
             <thead>
               <tr>
@@ -119,9 +134,12 @@
             <span class="method method-post">POST</span>
             <code>/pdf/generate</code>
           </div>
-          <p>Render HTML to PDF with headless Chromium.</p>
+          <p>
+            Render a PDF from HTML or by navigating to a URL. Provide <code>html</code>
+            <strong>or</strong> <code>url</code> — the two fields are mutually exclusive.
+          </p>
 
-          <h3>Request body</h3>
+          <h3>Request body (HTML)</h3>
           <div class="code-panel">
             <pre><code>{
   "html": "&lt;html&gt;&lt;body&gt;&lt;h1&gt;Hello&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;",
@@ -138,6 +156,17 @@
 }</code></pre>
           </div>
 
+          <h3>Request body (URL)</h3>
+          <div class="code-panel">
+            <pre><code>{
+  "url": "https://example.com",
+  "cookies": [{ "name": "session", "value": "abc123", "domain": "example.com" }],
+  "extraHeaders": { "Authorization": "Bearer my-token" },
+  "paper": { "size": "A4" },
+  "stream": false
+}</code></pre>
+          </div>
+
           <table>
             <thead>
               <tr>
@@ -148,8 +177,11 @@
               </tr>
             </thead>
             <tbody>
-              <tr><td><code>html</code></td><td>string</td><td>yes</td><td>HTML to render</td></tr>
-              <tr><td><code>css</code></td><td>string</td><td>no</td><td>Extra CSS injected after HTML is set</td></tr>
+              <tr><td><code>html</code></td><td>string</td><td>one of html/url</td><td>HTML to render</td></tr>
+              <tr><td><code>url</code></td><td>string</td><td>one of html/url</td><td>URL to navigate to and render</td></tr>
+              <tr><td><code>css</code></td><td>string</td><td>no</td><td>Extra CSS injected after the page loads</td></tr>
+              <tr><td><code>cookies</code></td><td>array</td><td>no</td><td>Cookies set before navigation (each with <code>name</code>, <code>value</code>, <code>domain</code>)</td></tr>
+              <tr><td><code>extraHeaders</code></td><td>object</td><td>no</td><td>HTTP headers sent with every request on the page</td></tr>
               <tr><td><code>paper.size</code></td><td>string</td><td>no</td><td><code>A4</code>, <code>A3</code>, <code>Letter</code>, <code>Legal</code>, <code>Tabloid</code></td></tr>
               <tr><td><code>paper.orientation</code></td><td>string</td><td>no</td><td><code>portrait</code> or <code>landscape</code></td></tr>
               <tr><td><code>options.margin</code></td><td>object</td><td>no</td><td><code>top</code>, <code>right</code>, <code>bottom</code>, <code>left</code> in CSS units</td></tr>
@@ -171,6 +203,59 @@
             <li><code>Content-Type: application/pdf</code></li>
             <li><code>Content-Disposition: attachment; filename="document.pdf"</code></li>
           </ul>
+
+          <div class="example-block">
+            <span class="example-label">Examples</span>
+            <p>Simple HTML to PDF:</p>
+            <div class="code-panel">
+              <pre><code>curl -s -X POST http://localhost:8080/pdf/generate \
+  -H "Content-Type: application/json" \
+  -d '{"html": "&lt;html&gt;&lt;body&gt;&lt;h1&gt;Hello&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;"}' | jq .</code></pre>
+            </div>
+
+            <p>URL to PDF:</p>
+            <div class="code-panel">
+              <pre><code>curl -s -X POST http://localhost:8080/pdf/generate \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}' | jq .</code></pre>
+            </div>
+
+            <p>URL with authentication (cookies + headers):</p>
+            <div class="code-panel">
+              <pre><code>curl -s -X POST http://localhost:8080/pdf/generate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com",
+    "cookies": [{"name": "session", "value": "abc123", "domain": "example.com"}],
+    "extraHeaders": {"Authorization": "Bearer my-token"}
+  }' | jq .</code></pre>
+            </div>
+
+            <p>Styled HTML with CSS, paper size, margins, and header/footer:</p>
+            <div class="code-panel">
+              <pre><code>curl -s -X POST http://localhost:8080/pdf/generate \
+  -H "Content-Type: application/json" \
+  -d '{
+    "html": "&lt;html&gt;&lt;body&gt;&lt;h1&gt;Invoice&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;",
+    "css": "body { font-family: Helvetica, sans-serif; }",
+    "paper": {"size": "A4"},
+    "options": {
+      "margin": {"top": "20mm", "bottom": "20mm", "left": "15mm", "right": "15mm"},
+      "printBackground": true,
+      "headerTemplate": "&lt;div style=\"font-size:8px;text-align:center;\"&gt;ACME Corp&lt;/div&gt;",
+      "footerTemplate": "&lt;div style=\"font-size:8px;text-align:center;\"&gt;Page &lt;span class=\"pageNumber\"&gt;&lt;/span&gt; / &lt;span class=\"totalPages\"&gt;&lt;/span&gt;&lt;/div&gt;"
+    }
+  }' | jq .</code></pre>
+            </div>
+
+            <p>Stream binary PDF to a file:</p>
+            <div class="code-panel">
+              <pre><code>curl -s -X POST http://localhost:8080/pdf/generate \
+  -H "Content-Type: application/json" \
+  -d '{"html": "&lt;html&gt;&lt;body&gt;&lt;h1&gt;Hello&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;", "stream": true}' \
+  -o output.pdf</code></pre>
+            </div>
+          </div>
         </section>
 
         <section id="get-pdf" class="endpoint-card">
@@ -183,6 +268,13 @@
             <pre><code>{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }</code></pre>
           </div>
           <p class="endpoint-note">Missing PDFs return <code>404</code>.</p>
+
+          <div class="example-block">
+            <span class="example-label">Example</span>
+            <div class="code-panel">
+              <pre><code>curl -s http://localhost:8080/pdf/550e8400-e29b-41d4-a716-446655440000 | jq .</code></pre>
+            </div>
+          </div>
         </section>
 
         <section id="delete-pdf" class="endpoint-card">
@@ -193,6 +285,14 @@
           <p>Permanently deletes a PDF from S3.</p>
           <div class="code-panel">
             <pre><code>HTTP 204 No Content</code></pre>
+          </div>
+
+          <div class="example-block">
+            <span class="example-label">Example</span>
+            <div class="code-panel">
+              <pre><code>curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+  http://localhost:8080/pdf/550e8400-e29b-41d4-a716-446655440000</code></pre>
+            </div>
           </div>
         </section>
 
@@ -241,6 +341,15 @@
             <li><code>Content-Type: application/pdf</code></li>
             <li><code>Content-Disposition: attachment; filename="merged.pdf"</code></li>
           </ul>
+
+          <div class="example-block">
+            <span class="example-label">Example</span>
+            <div class="code-panel">
+              <pre><code>curl -s -X POST http://localhost:8080/pdf/merge \
+  -H "Content-Type: application/json" \
+  -d '{"ids": ["ID_1", "ID_2"]}' | jq .</code></pre>
+            </div>
+          </div>
         </section>
 
         <section id="split" class="endpoint-card">
@@ -290,6 +399,15 @@
             Invalid expressions and page ranges that resolve to no valid pages return
             <code>400</code>. Missing PDFs return <code>404</code>.
           </p>
+
+          <div class="example-block">
+            <span class="example-label">Example</span>
+            <div class="code-panel">
+              <pre><code>curl -s -X POST http://localhost:8080/pdf/split \
+  -H "Content-Type: application/json" \
+  -d '{"id": "PDF_ID", "pages": "1-3,5"}' | jq .</code></pre>
+            </div>
+          </div>
         </section>
 
         <section id="compress" class="endpoint-card">
@@ -336,6 +454,15 @@
             <li><code>Content-Type: application/pdf</code></li>
             <li><code>Content-Disposition: attachment; filename="compressed.pdf"</code></li>
           </ul>
+
+          <div class="example-block">
+            <span class="example-label">Example</span>
+            <div class="code-panel">
+              <pre><code>curl -s -X POST http://localhost:8080/pdf/compress \
+  -H "Content-Type: application/json" \
+  -d '{"id": "PDF_ID"}' | jq .</code></pre>
+            </div>
+          </div>
         </section>
 
         <section id="pdfa" class="endpoint-card">
@@ -383,6 +510,15 @@
             <li><code>Content-Type: application/pdf</code></li>
             <li><code>Content-Disposition: attachment; filename="pdfa.pdf"</code></li>
           </ul>
+
+          <div class="example-block">
+            <span class="example-label">Example</span>
+            <div class="code-panel">
+              <pre><code>curl -s -X POST http://localhost:8080/pdf/pdfa \
+  -H "Content-Type: application/json" \
+  -d '{"id": "PDF_ID", "conformance": "2b"}' | jq .</code></pre>
+            </div>
+          </div>
         </section>
       </div>
     </main>

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -232,8 +232,8 @@ p {
 
 .code-panel {
   overflow-x: auto;
-  padding: 1rem;
-  border-radius: var(--radius-md);
+  padding: 0.7rem 0.9rem;
+  border-radius: var(--radius-sm);
   background: linear-gradient(180deg, #17222d 0%, #0e171f 100%);
   color: #edf3f8;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
@@ -295,20 +295,41 @@ p {
 .api-main {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
+  gap: 1rem;
 }
 
-.reference-hero,
-.endpoint-card {
+.reference-hero {
   padding: 1.8rem;
   border-radius: var(--radius-lg);
+}
+
+.endpoint-card {
+  padding: 1.4rem 1.6rem;
+  border-radius: var(--radius-lg);
+}
+
+.endpoint-card h3 {
+  margin-top: 1.2rem;
+  margin-bottom: 0.4rem;
+}
+
+.endpoint-card p {
+  margin-bottom: 0.6rem;
+}
+
+.endpoint-card .code-panel {
+  margin-bottom: 0.5rem;
+}
+
+.endpoint-card table {
+  margin: 0.6rem 0;
 }
 
 .endpoint-heading {
   display: flex;
   align-items: center;
   gap: 0.85rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
   font-size: 1.3rem;
   font-weight: 700;
 }
@@ -350,6 +371,37 @@ p {
   color: var(--muted);
 }
 
+.example-block {
+  margin-top: 1.2rem;
+  padding: 1rem 1.2rem;
+  border-radius: var(--radius-sm);
+  border: 1px dashed rgba(29, 114, 106, 0.3);
+  background: var(--teal-soft);
+}
+
+.example-block .example-label {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: var(--teal);
+  color: #fff;
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.example-block p {
+  margin-bottom: 0.35rem;
+  font-size: 0.92rem;
+  color: var(--muted);
+}
+
+.example-block .code-panel {
+  margin-bottom: 0.6rem;
+}
+
 table {
   width: 100%;
   border-collapse: collapse;
@@ -359,7 +411,7 @@ table {
 
 th,
 td {
-  padding: 0.8rem 0.75rem;
+  padding: 0.5rem 0.6rem;
   text-align: left;
   vertical-align: top;
   border-bottom: 1px solid var(--line);

--- a/docs/index.html
+++ b/docs/index.html
@@ -134,17 +134,47 @@ curl -s -X POST http://localhost:8080/pdf/generate \
         </div>
       </section>
 
-      <section id="deployment" class="site-width deployment-banner">
+      <section id="deployment" class="site-width section-grid">
         <div>
           <p class="section-kicker">Deployment</p>
-          <h2>Published by GitHub Pages, deployable to AWS Lambda</h2>
+          <h2>Ship to Lambda or any Docker host</h2>
           <p>
-            This docs site is published from the <code>docs/</code> directory via GitHub
-            Actions. The API itself deploys with SAM as a container image and includes a
-            smoke test step after deployment.
+            The same container image deploys to AWS Lambda via SAM or runs as a
+            plain Docker service on ECS, Fly.io, Railway, or any host with Docker.
           </p>
         </div>
-        <a class="button button-secondary" href="./api/">Browse the API reference</a>
+
+        <div class="code-panel">
+          <pre><code># AWS Lambda (SAM)
+sam build
+sam deploy
+
+# Docker — anywhere
+docker run -p 8080:8080 --env-file .env \
+  ghcr.io/alegerber/folio:latest</code></pre>
+        </div>
+      </section>
+
+      <section class="site-width stack-layout">
+        <div class="stack-card">
+          <p class="section-kicker">Lambda</p>
+          <h2>SAM + GitHub Actions</h2>
+          <p>
+            Every merge to <code>main</code> triggers <code>sam build</code> &rarr;
+            <code>sam deploy</code> &rarr; smoke test. Auth uses GitHub OIDC &rarr; AWS STS.
+            Recommended: 2048 MB memory, 120 s timeout.
+          </p>
+        </div>
+
+        <div class="stack-card">
+          <p class="section-kicker">Docker</p>
+          <h2>Build or pull from GHCR</h2>
+          <p>
+            Prebuilt images are published on every release. Tags:
+            <code>latest</code>, <code>x.y.z</code>, <code>x.y</code>.
+            Pass your env vars and run on any container platform.
+          </p>
+        </div>
       </section>
     </main>
 


### PR DESCRIPTION
## Summary

- Add highlighted curl examples to every endpoint in the API reference docs, wrapped in a teal "EXAMPLE" badge block with dashed border for clear visual separation
- Document the new `url`, `cookies`, and `extraHeaders` fields on `POST /pdf/generate` (HTML and URL request body variants)
- Tighten spacing across the API reference: smaller code panel padding, reduced card/table gaps, compact endpoint headings
- Rework the landing page deployment section to focus on AWS SAM and Docker instead of GitHub Pages — includes a code panel with `sam deploy` and `docker run`, plus Lambda and Docker detail cards

## Changed files

- `docs/api/index.html` — curl examples for all 10 endpoints, URL rendering docs
- `docs/assets/styles.css` — `.example-block` styles, tighter layout
- `docs/index.html` — deployment section rewrite
- `.gitignore` — add `.playwright-mcp`

## Test plan

- [x] Open `docs/index.html` locally and verify the deployment section shows SAM + Docker content
- [x] Open `docs/api/index.html` and verify each endpoint has a teal example block
- [x] Check responsive layout at mobile widths
- [x] Verify no broken links in the nav sidebar
