### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     name: Typecheck


### PR DESCRIPTION
Potential fix for [https://github.com/alegerber/folio/security/code-scanning/5](https://github.com/alegerber/folio/security/code-scanning/5)

Add an explicit workflow-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege defaults.

Best fix here (without changing functionality): set root-level permissions to:

- `contents: read`

This is the minimal recommended scope and is sufficient for `actions/checkout` and read-only CI tasks. None of the shown jobs require writing to issues, PRs, packages, or repository contents, and Docker build is configured with `push: false`, so no extra write scopes are needed.

Change location:
- File: `.github/workflows/ci.yml`
- Insert `permissions:` between the `on:` block and `jobs:` block.

No imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
