### PR TITLE
Feat/ssrf protection

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,5 +8,35 @@
       "Bash(npm run lint)",
       "Bash(npm run typecheck)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -qE 'git\\s+commit'; then branch=$(git branch --show-current 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Direct commits to main are not allowed — use a feature branch and merge via pull request.\"}}'; elif [ \"$branch\" = \"beta\" ]; then stat=$(git diff --cached --shortstat 2>/dev/null); files=$(git diff --cached --name-only 2>/dev/null | wc -l | tr -d ' '); ins=$(echo \"$stat\" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' | head -1); del=$(echo \"$stat\" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' | head -1); changes=$(( ${ins:-0} + ${del:-0} )); if [ \"$files\" -gt 10 ] || [ \"$changes\" -gt 200 ]; then echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"Large change detected on beta ($files files, $changes lines changed). Prefer smaller commits or use a feature branch.\\\"}}\"; fi; fi; fi"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); [ -n \"$f\" ] && echo \"$f\" | grep -qvE '(README|AGENTS)\\.md$' && echo \"$f\" | grep -qE '\\.(yml|yaml|conf|sql)$|Dockerfile' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Structural file changed — check if README.md or AGENTS.md need to be updated.\"}}' || true"
+          },
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); if echo \"$f\" | grep -qE '\\.tsx?$'; then npx vitest run 2>&1 || exit 2; fi",
+            "statusMessage": "Running unit tests...",
+            "asyncRewake": true
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,11 @@
           {
             "type": "command",
             "command": "cmd=$(jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -qE 'git\\s+commit'; then branch=$(git branch --show-current 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Direct commits to main are not allowed — use a feature branch and merge via pull request.\"}}'; elif [ \"$branch\" = \"beta\" ]; then stat=$(git diff --cached --shortstat 2>/dev/null); files=$(git diff --cached --name-only 2>/dev/null | wc -l | tr -d ' '); ins=$(echo \"$stat\" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' | head -1); del=$(echo \"$stat\" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' | head -1); changes=$(( ${ins:-0} + ${del:-0} )); if [ \"$files\" -gt 10 ] || [ \"$changes\" -gt 200 ]; then echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"Large change detected on beta ($files files, $changes lines changed). Prefer smaller commits or use a feature branch.\\\"}}\"; fi; fi; fi"
+          },
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -qE 'git\\s+commit'; then npm run lint 2>&1 && npm run typecheck 2>&1 && npx vitest run 2>&1 || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Checks failed (lint / typecheck / tests) — fix errors before committing.\"}}'; fi",
+            "statusMessage": "Running lint, typecheck & tests..."
           }
         ]
       }
@@ -28,12 +33,6 @@
           {
             "type": "command",
             "command": "f=$(jq -r '.tool_input.file_path // empty'); [ -n \"$f\" ] && echo \"$f\" | grep -qvE '(README|AGENTS)\\.md$' && echo \"$f\" | grep -qE '\\.(yml|yaml|conf|sql)$|Dockerfile' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Structural file changed — check if README.md or AGENTS.md need to be updated.\"}}' || true"
-          },
-          {
-            "type": "command",
-            "command": "f=$(jq -r '.tool_input.file_path // empty'); if echo \"$f\" | grep -qE '\\.tsx?$'; then npx vitest run 2>&1 || exit 2; fi",
-            "statusMessage": "Running unit tests...",
-            "asyncRewake": true
           }
         ]
       }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -12,6 +12,7 @@ const envSchema = z.object({
   PORT: z.coerce.number().int().positive().default(8080),
   API_KEY: z.string().min(32).optional(),
   GHOSTSCRIPT_PATH: z.string().optional(),
+  SSRF_PROTECTION: z.string().optional().transform((v) => v !== 'false'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/routes/pdf/handler.ts
+++ b/src/routes/pdf/handler.ts
@@ -12,6 +12,8 @@ import type { PdfService } from '../../services/pdf/PdfService.js';
 import type { StorageService, StoredPdf } from '../../services/storage/StorageService.js';
 import type { MetricsService } from '../../services/metrics/MetricsService.js';
 import type { PdfOperationsService } from '../../services/pdf/PdfOperationsService.js';
+import { assertSafeUrl, SsrfError } from '../../utils/ssrf.js';
+import { env } from '../../config/env.js';
 
 function sendStoredPdf(reply: FastifyReply, storedPdf: StoredPdf) {
   return reply.send({ statusCode: 200, data: storedPdf });
@@ -141,6 +143,17 @@ export function createGenerateHandler(
     }
     if (generateInput.html && generateInput.url) {
       return reply.badRequest('Provide either html or url, not both');
+    }
+
+    if (generateInput.url && env.SSRF_PROTECTION) {
+      try {
+        await assertSafeUrl(generateInput.url);
+      } catch (err) {
+        if (err instanceof SsrfError) {
+          return reply.status(400).send({ statusCode: 400, error: err.message });
+        }
+        throw err;
+      }
     }
 
     const start = Date.now();

--- a/src/utils/ssrf.test.ts
+++ b/src/utils/ssrf.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { assertSafeUrl, SsrfError } from './ssrf.js';
+
+vi.mock('dns/promises', () => ({
+  lookup: vi.fn(),
+}));
+
+import { lookup } from 'dns/promises';
+const mockLookup = vi.mocked(lookup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('assertSafeUrl — scheme checks', () => {
+  it('allows http scheme', async () => {
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    await expect(assertSafeUrl('http://example.com')).resolves.toBeUndefined();
+  });
+
+  it('allows https scheme', async () => {
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    await expect(assertSafeUrl('https://example.com')).resolves.toBeUndefined();
+  });
+
+  it('blocks file:// scheme', async () => {
+    await expect(assertSafeUrl('file:///etc/passwd')).rejects.toThrow(SsrfError);
+    await expect(assertSafeUrl('file:///etc/passwd')).rejects.toThrow('"file:" is not allowed');
+  });
+
+  it('blocks ftp:// scheme', async () => {
+    await expect(assertSafeUrl('ftp://example.com/file')).rejects.toThrow(SsrfError);
+  });
+
+  it('blocks data:// scheme', async () => {
+    await expect(assertSafeUrl('data:text/html,<h1>hi</h1>')).rejects.toThrow(SsrfError);
+  });
+});
+
+describe('assertSafeUrl — private IP ranges blocked', () => {
+  const privateIps = [
+    ['10.0.0.1', 'RFC1918 class A'],
+    ['10.255.255.255', 'RFC1918 class A edge'],
+    ['172.16.0.1', 'RFC1918 class B low'],
+    ['172.31.255.255', 'RFC1918 class B high'],
+    ['192.168.0.1', 'RFC1918 class C'],
+    ['127.0.0.1', 'loopback'],
+    ['127.0.0.2', 'loopback range'],
+    ['169.254.169.254', 'link-local / EC2 metadata'],
+    ['169.254.0.1', 'link-local range'],
+    ['::1', 'IPv6 loopback'],
+    ['fc00::1', 'IPv6 ULA'],
+    ['fe80::1', 'IPv6 link-local'],
+  ] as const;
+
+  for (const [ip, label] of privateIps) {
+    it(`blocks ${label} (${ip}) when given directly`, async () => {
+      await expect(assertSafeUrl(`http://${ip.includes(':') ? `[${ip}]` : ip}/path`)).rejects.toThrow(SsrfError);
+    });
+  }
+
+  it('blocks private IP resolved from hostname', async () => {
+    mockLookup.mockResolvedValue({ address: '10.0.0.1', family: 4 });
+    await expect(assertSafeUrl('http://internal.example.com')).rejects.toThrow(SsrfError);
+  });
+
+  it('includes the resolved IP in the error message', async () => {
+    mockLookup.mockResolvedValue({ address: '192.168.1.100', family: 4 });
+    await expect(assertSafeUrl('http://evil.example.com')).rejects.toThrow('192.168.1.100');
+  });
+});
+
+describe('assertSafeUrl — public IPs allowed', () => {
+  const publicIps = ['8.8.8.8', '93.184.216.34', '1.1.1.1', '172.15.255.255', '172.32.0.0'];
+
+  for (const ip of publicIps) {
+    it(`allows public IP ${ip}`, async () => {
+      await expect(assertSafeUrl(`http://${ip}/`)).resolves.toBeUndefined();
+    });
+  }
+
+  it('allows public hostname resolving to public IP', async () => {
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    await expect(assertSafeUrl('https://example.com')).resolves.toBeUndefined();
+  });
+});
+
+describe('assertSafeUrl — hostname resolution', () => {
+  it('calls lookup for non-IP hostnames', async () => {
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    await assertSafeUrl('https://example.com/path?q=1');
+    expect(mockLookup).toHaveBeenCalledWith('example.com', { verbatim: true });
+  });
+
+  it('does not call lookup for IP hostnames', async () => {
+    await assertSafeUrl('https://93.184.216.34/');
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it('propagates DNS lookup errors', async () => {
+    mockLookup.mockRejectedValue(new Error('ENOTFOUND'));
+    await expect(assertSafeUrl('https://does-not-exist.invalid')).rejects.toThrow('ENOTFOUND');
+  });
+});

--- a/src/utils/ssrf.ts
+++ b/src/utils/ssrf.ts
@@ -1,0 +1,49 @@
+import { isIP } from 'net';
+import { lookup } from 'dns/promises';
+
+const BLOCKED_RANGES = [
+  /^10\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,
+  /^127\./,
+  /^169\.254\./,
+  /^::1$/,
+  /^fc00:/,
+  /^fe80:/,
+];
+
+export async function assertSafeUrl(rawUrl: string): Promise<void> {
+  const parsed = new URL(rawUrl);
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new SsrfError(`Scheme "${parsed.protocol}" is not allowed`);
+  }
+
+  // URL spec wraps IPv6 literals in brackets: "[::1]" — strip them before isIP/lookup
+  const rawHostname = parsed.hostname;
+  const hostname =
+    rawHostname.startsWith('[') && rawHostname.endsWith(']')
+      ? rawHostname.slice(1, -1)
+      : rawHostname;
+  let ip: string;
+
+  if (isIP(hostname)) {
+    ip = hostname;
+  } else {
+    const result = await lookup(hostname, { verbatim: true });
+    ip = result.address;
+  }
+
+  for (const range of BLOCKED_RANGES) {
+    if (range.test(ip)) {
+      throw new SsrfError(`URL resolves to a private address (${ip})`);
+    }
+  }
+}
+
+export class SsrfError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SsrfError';
+  }
+}


### PR DESCRIPTION
feat(security): add SSRF protection for URL rendering
Block requests to private/loopback IP ranges and non-HTTP(S) schemes
before Puppeteer loads any caller-supplied URL. Covers EC2 metadata
(169.254.x), RFC1918, loopback, and IPv6 private ranges.

- src/utils/ssrf.ts: assertSafeUrl() with IP range + scheme checks
- src/utils/ssrf.test.ts: 28 unit tests (all scenarios from plan)
- src/config/env.ts: SSRF_PROTECTION env var (default true)
- src/routes/pdf/handler.ts: guard applied before page.goto()

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>