### PR TITLE
feat(screenshot): add POST /screenshot endpoint

### DIFF
--- a/src/routes/screenshot/handler.ts
+++ b/src/routes/screenshot/handler.ts
@@ -1,0 +1,49 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { ScreenshotRequestInput } from './schema.js';
+import type { ScreenshotService } from '../../services/screenshot/ScreenshotService.js';
+import type { StorageService } from '../../services/storage/StorageService.js';
+import { assertSafeUrl, SsrfError } from '../../utils/ssrf.js';
+import { env } from '../../config/env.js';
+
+export function createScreenshotHandler(
+  screenshotService: ScreenshotService,
+  storageService: StorageService,
+) {
+  return async function screenshotHandler(
+    request: FastifyRequest<{ Body: ScreenshotRequestInput }>,
+    reply: FastifyReply,
+  ) {
+    const { stream, ...captureInput } = request.body;
+
+    if (!captureInput.html && !captureInput.url) {
+      return reply.badRequest('Provide either html or url');
+    }
+    if (captureInput.html && captureInput.url) {
+      return reply.badRequest('Provide either html or url, not both');
+    }
+
+    if (captureInput.url && env.SSRF_PROTECTION) {
+      try {
+        await assertSafeUrl(captureInput.url);
+      } catch (err) {
+        if (err instanceof SsrfError) {
+          return reply.status(400).send({ statusCode: 400, error: err.message });
+        }
+        throw err;
+      }
+    }
+
+    const { buffer, mimeType } = await screenshotService.capture(captureInput);
+    const format = captureInput.format ?? 'png';
+
+    if (stream) {
+      return reply
+        .header('Content-Type', mimeType)
+        .header('Content-Disposition', `attachment; filename="screenshot.${format}"`)
+        .send(buffer);
+    }
+
+    const stored = await storageService.uploadImage(buffer, format, mimeType);
+    return reply.send({ statusCode: 200, data: { url: stored.url } });
+  };
+}

--- a/src/routes/screenshot/index.ts
+++ b/src/routes/screenshot/index.ts
@@ -1,0 +1,20 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { screenshotRequestJsonSchema } from './schema.js';
+import { createScreenshotHandler } from './handler.js';
+import type { ScreenshotService } from '../../services/screenshot/ScreenshotService.js';
+import type { StorageService } from '../../services/storage/StorageService.js';
+
+interface ScreenshotRouteOptions {
+  screenshotService: ScreenshotService;
+  storageService: StorageService;
+}
+
+export const screenshotRoutes: FastifyPluginAsync<ScreenshotRouteOptions> = async (
+  fastify,
+  { screenshotService, storageService },
+) => {
+  fastify.post('/screenshot', {
+    schema: { body: screenshotRequestJsonSchema },
+    handler: createScreenshotHandler(screenshotService, storageService),
+  });
+};

--- a/src/routes/screenshot/schema.ts
+++ b/src/routes/screenshot/schema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const screenshotRequestSchema = z.object({
+  html: z.string().min(1).optional(),
+  url: z.url().optional(),
+  css: z.string().optional(),
+  viewport: z
+    .object({
+      width: z.number().int().min(1).max(3840).default(1280),
+      height: z.number().int().min(1).max(2160).default(720),
+    })
+    .optional(),
+  format: z.enum(['png', 'jpeg', 'webp']).default('png'),
+  quality: z.number().int().min(1).max(100).optional(),
+  fullPage: z.boolean().default(false),
+  clip: z
+    .object({
+      x: z.number(),
+      y: z.number(),
+      width: z.number().positive(),
+      height: z.number().positive(),
+    })
+    .optional(),
+  stream: z.boolean().default(false),
+});
+
+export type ScreenshotRequestInput = z.infer<typeof screenshotRequestSchema>;
+
+const { $schema: _$schema, ...screenshotRequestJsonSchema } = z.toJSONSchema(screenshotRequestSchema);
+export { screenshotRequestJsonSchema };

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,10 +6,12 @@ import { sensiblePlugin } from './plugins/sensible.js';
 import { healthRoutes } from './routes/health/index.js';
 import { pdfRoutes } from './routes/pdf/index.js';
 import { metricsRoutes } from './routes/metrics/index.js';
+import { screenshotRoutes } from './routes/screenshot/index.js';
 import { PdfService } from './services/pdf/PdfService.js';
 import { PdfOperationsService } from './services/pdf/PdfOperationsService.js';
 import { StorageService } from './services/storage/StorageService.js';
 import { MetricsService } from './services/metrics/MetricsService.js';
+import { ScreenshotService } from './services/screenshot/ScreenshotService.js';
 
 export async function buildApp() {
   const fastify = Fastify({
@@ -25,6 +27,7 @@ export async function buildApp() {
   const pdfService = new PdfService();
   const metricsService = new MetricsService();
   const opsService = new PdfOperationsService(env.GHOSTSCRIPT_PATH);
+  const screenshotService = new ScreenshotService(pdfService);
 
   await fastify.register(sensiblePlugin);
   await fastify.register(authPlugin);
@@ -37,6 +40,10 @@ export async function buildApp() {
     opsService,
   });
   await fastify.register(metricsRoutes, { metricsService });
+  await fastify.register(screenshotRoutes, {
+    screenshotService,
+    storageService: new StorageService(fastify.s3, fastify.s3Public),
+  });
 
   fastify.addHook('onReady', async () => {
     // Warm up the browser in the background — don't block the hook since

--- a/src/services/screenshot/ScreenshotService.test.ts
+++ b/src/services/screenshot/ScreenshotService.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ScreenshotService } from './ScreenshotService.js';
+import type { PdfService } from '../pdf/PdfService.js';
+
+const mockScreenshot = vi.fn().mockResolvedValue(Buffer.from('PNG_DATA'));
+const mockPageClose = vi.fn().mockResolvedValue(undefined);
+const mockSetContent = vi.fn().mockResolvedValue(undefined);
+const mockGoto = vi.fn().mockResolvedValue(undefined);
+const mockAddStyleTag = vi.fn().mockResolvedValue(undefined);
+const mockSetViewport = vi.fn().mockResolvedValue(undefined);
+
+const mockNewPage = vi.fn().mockResolvedValue({
+  setViewport: mockSetViewport,
+  setContent: mockSetContent,
+  goto: mockGoto,
+  addStyleTag: mockAddStyleTag,
+  screenshot: mockScreenshot,
+  close: mockPageClose,
+});
+
+const mockBrowser = { newPage: mockNewPage };
+const mockGetBrowser = vi.fn().mockResolvedValue(mockBrowser);
+const mockPdfService = { getBrowser: mockGetBrowser } as unknown as PdfService;
+
+describe('ScreenshotService', () => {
+  let screenshotService: ScreenshotService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    screenshotService = new ScreenshotService(mockPdfService);
+  });
+
+  it('captures a PNG screenshot from HTML', async () => {
+    const { buffer, mimeType } = await screenshotService.capture({
+      html: '<html><body>Hello</body></html>',
+    });
+
+    expect(mockSetContent).toHaveBeenCalledWith('<html><body>Hello</body></html>', {
+      waitUntil: 'networkidle0',
+    });
+    expect(mockGoto).not.toHaveBeenCalled();
+    expect(mockScreenshot).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'png', fullPage: false }),
+    );
+    expect(mimeType).toBe('image/png');
+    expect(buffer).toBeInstanceOf(Buffer);
+  });
+
+  it('navigates to a URL when url is provided', async () => {
+    await screenshotService.capture({ url: 'https://example.com' });
+
+    expect(mockGoto).toHaveBeenCalledWith('https://example.com', {
+      waitUntil: 'networkidle0',
+      timeout: 25_000,
+    });
+    expect(mockSetContent).not.toHaveBeenCalled();
+  });
+
+  it('injects CSS when css is provided', async () => {
+    await screenshotService.capture({
+      html: '<html></html>',
+      css: 'body { background: red; }',
+    });
+
+    expect(mockAddStyleTag).toHaveBeenCalledWith({ content: 'body { background: red; }' });
+  });
+
+  it('does not call addStyleTag when css is not provided', async () => {
+    await screenshotService.capture({ html: '<html></html>' });
+
+    expect(mockAddStyleTag).not.toHaveBeenCalled();
+  });
+
+  it('uses custom viewport when provided', async () => {
+    await screenshotService.capture({
+      html: '<html></html>',
+      viewport: { width: 800, height: 600 },
+    });
+
+    expect(mockSetViewport).toHaveBeenCalledWith({ width: 800, height: 600 });
+  });
+
+  it('defaults to 1280x720 viewport', async () => {
+    await screenshotService.capture({ html: '<html></html>' });
+
+    expect(mockSetViewport).toHaveBeenCalledWith({ width: 1280, height: 720 });
+  });
+
+  it('captures JPEG with quality', async () => {
+    const { mimeType } = await screenshotService.capture({
+      html: '<html></html>',
+      format: 'jpeg',
+      quality: 80,
+    });
+
+    expect(mockScreenshot).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'jpeg', quality: 80 }),
+    );
+    expect(mimeType).toBe('image/jpeg');
+  });
+
+  it('ignores quality for PNG', async () => {
+    await screenshotService.capture({
+      html: '<html></html>',
+      format: 'png',
+      quality: 80,
+    });
+
+    const screenshotCall = mockScreenshot.mock.calls[0][0];
+    expect(screenshotCall.quality).toBeUndefined();
+  });
+
+  it('captures full page when fullPage is true', async () => {
+    await screenshotService.capture({ html: '<html></html>', fullPage: true });
+
+    expect(mockScreenshot).toHaveBeenCalledWith(expect.objectContaining({ fullPage: true }));
+  });
+
+  it('applies clip region when provided', async () => {
+    const clip = { x: 0, y: 0, width: 400, height: 300 };
+
+    await screenshotService.capture({ html: '<html></html>', clip });
+
+    expect(mockScreenshot).toHaveBeenCalledWith(expect.objectContaining({ clip }));
+  });
+
+  it('closes the page after capture even on error', async () => {
+    mockSetContent.mockRejectedValueOnce(new Error('Load failed'));
+
+    await expect(
+      screenshotService.capture({ html: '<html></html>' }),
+    ).rejects.toThrow('Load failed');
+
+    expect(mockPageClose).toHaveBeenCalledOnce();
+  });
+
+  it('reuses the browser from PdfService', async () => {
+    await screenshotService.capture({ html: '<html></html>' });
+    await screenshotService.capture({ html: '<html></html>' });
+
+    expect(mockGetBrowser).toHaveBeenCalledTimes(2);
+    expect(mockNewPage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/screenshot/ScreenshotService.ts
+++ b/src/services/screenshot/ScreenshotService.ts
@@ -1,0 +1,39 @@
+import type { PdfService } from '../pdf/PdfService.js';
+import type { ScreenshotRequest } from '../../types/index.js';
+
+export class ScreenshotService {
+  constructor(private readonly pdfService: PdfService) {}
+
+  async capture(request: ScreenshotRequest): Promise<{ buffer: Buffer; mimeType: string }> {
+    const format = request.format ?? 'png';
+    const browser = await this.pdfService.getBrowser();
+    const page = await browser.newPage();
+
+    try {
+      await page.setViewport(request.viewport ?? { width: 1280, height: 720 });
+
+      if (request.url) {
+        await page.goto(request.url, { waitUntil: 'networkidle0', timeout: 25_000 });
+      } else {
+        await page.setContent(request.html!, { waitUntil: 'networkidle0' });
+      }
+
+      if (request.css) {
+        await page.addStyleTag({ content: request.css });
+      }
+
+      const buffer = Buffer.from(
+        await page.screenshot({
+          type: format,
+          quality: format === 'png' ? undefined : request.quality,
+          fullPage: request.fullPage ?? false,
+          clip: request.clip,
+        }),
+      );
+
+      return { buffer, mimeType: `image/${format}` };
+    } finally {
+      await page.close();
+    }
+  }
+}

--- a/src/services/storage/StorageService.ts
+++ b/src/services/storage/StorageService.ts
@@ -119,4 +119,29 @@ export class StorageService {
 
     return { id, url };
   }
+
+  async uploadImage(buffer: Buffer, format: string, contentType: string): Promise<StoredPdf> {
+    const id = randomUUID();
+    const key = `screenshots/${id}.${format}`;
+
+    await this.s3.send(
+      new PutObjectCommand({
+        Bucket: env.S3_BUCKET,
+        Key: key,
+        Body: buffer,
+        ContentType: contentType,
+      }),
+    );
+
+    const url = await getSignedUrl(
+      this.s3Public,
+      new GetObjectCommand({
+        Bucket: env.S3_BUCKET,
+        Key: key,
+      }),
+      { expiresIn: env.SIGNED_URL_EXPIRY_SECONDS },
+    );
+
+    return { id, url };
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,3 +42,22 @@ export interface GenerateResponse {
     url: string;
   };
 }
+
+export interface ScreenshotRequest {
+  html?: string;
+  url?: string;
+  css?: string;
+  viewport?: { width: number; height: number };
+  format?: 'png' | 'jpeg' | 'webp';
+  quality?: number;
+  fullPage?: boolean;
+  clip?: { x: number; y: number; width: number; height: number };
+  stream?: boolean;
+}
+
+export interface ScreenshotResponse {
+  statusCode: number;
+  data: {
+    url: string;
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `POST /screenshot` — renders HTML or a URL with Puppeteer and returns a PNG, JPEG, or WebP image
- Supports `stream: true` (binary response) and `stream: false` (S3 presigned URL, stored under `screenshots/{id}.{format}`)
- Viewport, `fullPage`, `clip`, and `quality` are all configurable
- SSRF protection applied to `url` requests (same guard as `/pdf/generate`)
- `ScreenshotService` reuses the existing `PdfService` browser instance

## Test plan

- [ ] `npx vitest run` — all 139 tests pass
- [ ] `POST /screenshot` with `html` + `stream: true` returns binary PNG
- [ ] `POST /screenshot` with `url` + `stream: false` returns S3 URL
- [ ] `POST /screenshot` with a private IP in `url` returns 400 (SSRF blocked)
- [ ] `POST /screenshot` with neither `html` nor `url` returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)