### PR TITLE
Release v1.1.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,5 +8,35 @@
       "Bash(npm run lint)",
       "Bash(npm run typecheck)"
     ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -qE 'git\\s+commit'; then branch=$(git branch --show-current 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Direct commits to main are not allowed — use a feature branch and merge via pull request.\"}}'; elif [ \"$branch\" = \"beta\" ]; then stat=$(git diff --cached --shortstat 2>/dev/null); files=$(git diff --cached --name-only 2>/dev/null | wc -l | tr -d ' '); ins=$(echo \"$stat\" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' | head -1); del=$(echo \"$stat\" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' | head -1); changes=$(( ${ins:-0} + ${del:-0} )); if [ \"$files\" -gt 10 ] || [ \"$changes\" -gt 200 ]; then echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"Large change detected on beta ($files files, $changes lines changed). Prefer smaller commits or use a feature branch.\\\"}}\"; fi; fi; fi"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); [ -n \"$f\" ] && echo \"$f\" | grep -qvE '(README|AGENTS)\\.md$' && echo \"$f\" | grep -qE '\\.(yml|yaml|conf|sql)$|Dockerfile' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Structural file changed — check if README.md or AGENTS.md need to be updated.\"}}' || true"
+          },
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); if echo \"$f\" | grep -qE '\\.tsx?$'; then npx vitest run 2>&1 || exit 2; fi",
+            "statusMessage": "Running unit tests...",
+            "asyncRewake": true
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npm run dev)",
+      "Bash(npm run build)",
+      "Bash(npm run test)",
+      "Bash(npm run test:cov)",
+      "Bash(npm run lint)",
+      "Bash(npm run typecheck)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -22,6 +22,11 @@
             "type": "command",
             "command": "cmd=$(jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -qE 'git\\s+commit'; then npm run lint 2>&1 && npm run typecheck 2>&1 && npx vitest run 2>&1 || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Checks failed (lint / typecheck / tests) — fix errors before committing.\"}}'; fi",
             "statusMessage": "Running lint, typecheck & tests..."
+          },
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -qE 'git\\s+commit'; then BASE=\"${SMOKE_TEST_URL:-http://localhost:8080}\"; if curl -sf -o /dev/null --max-time 2 \"$BASE/health\" 2>/dev/null; then ROOT=$(git rev-parse --show-toplevel 2>/dev/null); if ! bash \"$ROOT/scripts/smoke-test.sh\" \"$BASE\" 2>&1; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Smoke test failed — fix the failing routes before committing.\"}}'; fi; else echo \"[smoke] skipped — no server reachable at $BASE\" >&2; fi; fi",
+            "statusMessage": "Running smoke test..."
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,11 @@
           {
             "type": "command",
             "command": "cmd=$(jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -qE 'git\\s+commit'; then branch=$(git branch --show-current 2>/dev/null); if [ \"$branch\" = \"main\" ]; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Direct commits to main are not allowed — use a feature branch and merge via pull request.\"}}'; elif [ \"$branch\" = \"beta\" ]; then stat=$(git diff --cached --shortstat 2>/dev/null); files=$(git diff --cached --name-only 2>/dev/null | wc -l | tr -d ' '); ins=$(echo \"$stat\" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' | head -1); del=$(echo \"$stat\" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' | head -1); changes=$(( ${ins:-0} + ${del:-0} )); if [ \"$files\" -gt 10 ] || [ \"$changes\" -gt 200 ]; then echo \"{\\\"hookSpecificOutput\\\":{\\\"hookEventName\\\":\\\"PreToolUse\\\",\\\"permissionDecision\\\":\\\"deny\\\",\\\"permissionDecisionReason\\\":\\\"Large change detected on beta ($files files, $changes lines changed). Prefer smaller commits or use a feature branch.\\\"}}\"; fi; fi; fi"
+          },
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // empty'); if echo \"$cmd\" | grep -qE 'git\\s+commit'; then npm run lint 2>&1 && npm run typecheck 2>&1 && npx vitest run 2>&1 || echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Checks failed (lint / typecheck / tests) — fix errors before committing.\"}}'; fi",
+            "statusMessage": "Running lint, typecheck & tests..."
           }
         ]
       }
@@ -28,12 +33,6 @@
           {
             "type": "command",
             "command": "f=$(jq -r '.tool_input.file_path // empty'); [ -n \"$f\" ] && echo \"$f\" | grep -qvE '(README|AGENTS)\\.md$' && echo \"$f\" | grep -qE '\\.(yml|yaml|conf|sql)$|Dockerfile' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Structural file changed — check if README.md or AGENTS.md need to be updated.\"}}' || true"
-          },
-          {
-            "type": "command",
-            "command": "f=$(jq -r '.tool_input.file_path // empty'); if echo \"$f\" | grep -qE '\\.tsx?$'; then npx vitest run 2>&1 || exit 2; fi",
-            "statusMessage": "Running unit tests...",
-            "asyncRewake": true
           }
         ]
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
   push:
-    branches: [main]
+    branches: [main, 'release/**']
 
 jobs:
   typecheck:

--- a/.github/workflows/cleanup-release.yml
+++ b/.github/workflows/cleanup-release.yml
@@ -14,19 +14,17 @@ permissions:
 
 jobs:
   cleanup:
-    name: Delete Release Stack & ECR Repo
+    name: Delete Release Stack
     runs-on: ubuntu-latest
 
     steps:
-      - name: Derive resource names
+      - name: Derive stack name
         id: env
         run: |
           SUFFIX=$(echo "${{ inputs.branch }}" | sed 's/[^a-zA-Z0-9]/-/g')
           STACK="folio-${SUFFIX}"
-          ECR="${{ secrets.ECR_REPOSITORY }}-${SUFFIX}"
           echo "stack-name=${STACK}" >> "$GITHUB_OUTPUT"
-          echo "ecr-repo=${ECR}" >> "$GITHUB_OUTPUT"
-          echo "Cleaning up stack=${STACK}, ecr=${ECR}"
+          echo "Cleaning up stack=${STACK}"
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -44,11 +42,3 @@ jobs:
           aws cloudformation wait stack-delete-complete \
             --stack-name "${{ steps.env.outputs.stack-name }}" \
             --region eu-central-1
-
-      - name: Delete ECR repository
-        run: |
-          aws ecr delete-repository \
-            --repository-name "${{ steps.env.outputs.ecr-repo }}" \
-            --region eu-central-1 \
-            --force \
-          || echo "ECR repository does not exist or was already deleted"

--- a/.github/workflows/cleanup-release.yml
+++ b/.github/workflows/cleanup-release.yml
@@ -1,0 +1,54 @@
+name: Cleanup Release Environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Release branch (z.B. release/v1.1.0)'
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  cleanup:
+    name: Delete Release Stack & ECR Repo
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Derive resource names
+        id: env
+        run: |
+          SUFFIX=$(echo "${{ inputs.branch }}" | sed 's/[^a-zA-Z0-9]/-/g')
+          STACK="folio-${SUFFIX}"
+          ECR="${{ secrets.ECR_REPOSITORY }}-${SUFFIX}"
+          echo "stack-name=${STACK}" >> "$GITHUB_OUTPUT"
+          echo "ecr-repo=${ECR}" >> "$GITHUB_OUTPUT"
+          echo "Cleaning up stack=${STACK}, ecr=${ECR}"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-deploy
+          aws-region: eu-central-1
+
+      - name: Delete CloudFormation stack
+        run: |
+          aws cloudformation delete-stack \
+            --stack-name "${{ steps.env.outputs.stack-name }}" \
+            --region eu-central-1
+
+          echo "Waiting for stack deletion..."
+          aws cloudformation wait stack-delete-complete \
+            --stack-name "${{ steps.env.outputs.stack-name }}" \
+            --region eu-central-1
+
+      - name: Delete ECR repository
+        run: |
+          aws ecr delete-repository \
+            --repository-name "${{ steps.env.outputs.ecr-repo }}" \
+            --region eu-central-1 \
+            --force \
+          || echo "ECR repository does not exist or was already deleted"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
 
 permissions:
   id-token: write
@@ -14,9 +14,23 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       api-url: ${{ steps.api-url.outputs.url }}
+      stack-name: ${{ steps.env.outputs.stack-name }}
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Derive environment
+        id: env
+        run: |
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          if [[ "$BRANCH" == "main" ]]; then
+            echo "stack-name=folio" >> "$GITHUB_OUTPUT"
+            echo "ecr-repo=${{ secrets.ECR_REPOSITORY }}" >> "$GITHUB_OUTPUT"
+          else
+            SUFFIX=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9]/-/g')
+            echo "stack-name=folio-${SUFFIX}" >> "$GITHUB_OUTPUT"
+            echo "ecr-repo=${{ secrets.ECR_REPOSITORY }}-${SUFFIX}" >> "$GITHUB_OUTPUT"
+          fi
 
       - uses: aws-actions/setup-sam@v2
 
@@ -26,14 +40,25 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-deploy
           aws-region: eu-central-1
 
+      - name: Ensure ECR repository exists
+        if: github.ref != 'refs/heads/main'
+        run: |
+          aws ecr describe-repositories \
+            --repository-names "${{ steps.env.outputs.ecr-repo }}" \
+            --region eu-central-1 2>/dev/null \
+          || aws ecr create-repository \
+            --repository-name "${{ steps.env.outputs.ecr-repo }}" \
+            --region eu-central-1 \
+            --image-scanning-configuration scanOnPush=true
+
       - name: SAM build
         run: sam build
 
       - name: SAM deploy
         run: |
           sam deploy \
-            --stack-name folio \
-            --image-repositories "FolioFunction=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/${{ secrets.ECR_REPOSITORY }}" \
+            --stack-name "${{ steps.env.outputs.stack-name }}" \
+            --image-repositories "FolioFunction=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/${{ steps.env.outputs.ecr-repo }}" \
             --s3-bucket "${{ secrets.SAM_ARTIFACT_BUCKET }}" \
             --region eu-central-1 \
             --capabilities CAPABILITY_IAM \
@@ -47,7 +72,7 @@ jobs:
         id: api-url
         run: |
           URL=$(aws cloudformation describe-stacks \
-            --stack-name folio \
+            --stack-name "${{ steps.env.outputs.stack-name }}" \
             --region eu-central-1 \
             --query 'Stacks[0].Outputs[?OutputKey==`ApiUrl`].OutputValue' \
             --output text)

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,11 +25,9 @@ jobs:
           BRANCH="${GITHUB_REF#refs/heads/}"
           if [[ "$BRANCH" == "main" ]]; then
             echo "stack-name=folio" >> "$GITHUB_OUTPUT"
-            echo "ecr-repo=${{ secrets.ECR_REPOSITORY }}" >> "$GITHUB_OUTPUT"
           else
             SUFFIX=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9]/-/g')
             echo "stack-name=folio-${SUFFIX}" >> "$GITHUB_OUTPUT"
-            echo "ecr-repo=${{ secrets.ECR_REPOSITORY }}-${SUFFIX}" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: aws-actions/setup-sam@v2
@@ -40,17 +38,6 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-deploy
           aws-region: eu-central-1
 
-      - name: Ensure ECR repository exists
-        if: github.ref != 'refs/heads/main'
-        run: |
-          aws ecr describe-repositories \
-            --repository-names "${{ steps.env.outputs.ecr-repo }}" \
-            --region eu-central-1 2>/dev/null \
-          || aws ecr create-repository \
-            --repository-name "${{ steps.env.outputs.ecr-repo }}" \
-            --region eu-central-1 \
-            --image-scanning-configuration scanOnPush=true
-
       - name: SAM build
         run: sam build
 
@@ -58,7 +45,7 @@ jobs:
         run: |
           sam deploy \
             --stack-name "${{ steps.env.outputs.stack-name }}" \
-            --image-repositories "FolioFunction=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/${{ steps.env.outputs.ecr-repo }}" \
+            --image-repositories "FolioFunction=${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.eu-central-1.amazonaws.com/${{ secrets.ECR_REPOSITORY }}" \
             --s3-bucket "${{ secrets.SAM_ARTIFACT_BUCKET }}" \
             --region eu-central-1 \
             --capabilities CAPABILITY_IAM \

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ Thumbs.db
 .plans
 
 # Claude
-.claude
+.claude/settings.local.json
 
 # AWS
 .aws-sam

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,9 @@ Metrics are in-memory (reset on restart). `MetricsService` is instantiated in `s
 
 ### POST /pdf/generate
 
-**Request body:**
+Accepts either `html` (raw HTML string) or `url` (navigates to the URL and renders the page). The two fields are mutually exclusive.
+
+**Request body (HTML):**
 ```json
 {
   "html": "<html>...</html>",
@@ -105,6 +107,17 @@ Metrics are in-memory (reset on restart). `MetricsService` is instantiated in `s
     "headerTemplate": "<div style=\"font-size:10px;\">Header</div>",
     "footerTemplate": "<div style=\"font-size:10px;\">Page <span class=\"pageNumber\"></span></div>"
   },
+  "stream": false
+}
+```
+
+**Request body (URL):**
+```json
+{
+  "url": "https://example.com",
+  "cookies": [{ "name": "session", "value": "abc123", "domain": "example.com" }],
+  "extraHeaders": { "Authorization": "Bearer token" },
+  "paper": { "size": "A4" },
   "stream": false
 }
 ```
@@ -319,13 +332,13 @@ Planned features are documented in `.plans/`. See [`.plans/PLAN.md`](.plans/PLAN
 | `additional-routes.md` | `GET /pdf/:id`, `DELETE /pdf/:id`, `POST /pdf/merge` |
 | `pdf-operations.md` | `POST /pdf/split`, `/pdf/compress`, `/pdf/pdfa` |
 | `open-source-publishing.md` | MIT license, GHCR image publishing, release-please, CONTRIBUTING |
+| `url-rendering.md` | Render a URL instead of raw HTML, with cookies and extra headers |
 
 ### Planned — Gotenberg feature parity
 
 | File | Description |
 |---|---|
 | `ssrf-protection.md` | Shared SSRF guard for URL-accepting endpoints |
-| `url-rendering.md` | Render a URL instead of raw HTML |
 | `screenshot-api.md` | `POST /screenshot` — HTML/URL → PNG/JPEG/WebP |
 | `libreoffice-conversion.md` | `POST /convert` — DOCX/XLSX/PPTX → PDF via LibreOffice (Docker/ECS only) |
 | `openapi-docs.md` | `GET /docs` Swagger UI + `GET /openapi.json` |

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ Folio is built for teams already on AWS who want a PDF service that fits their e
 - S3 upload plus presigned URL responses
 - API key authentication
 - HTML to PDF generation with CSS, headers, and footers
+- URL rendering — navigate to a URL and render the page as PDF (supports cookies and custom headers)
 - PDF merge, split, compress, and PDF/A routes
 - Prometheus-style metrics
-- Planned URL rendering, screenshots, OpenAPI docs, and document conversion
+- Planned screenshots, OpenAPI docs, and document conversion
 
 ---
 
@@ -252,7 +253,7 @@ docker run -p 8080:8080 --env-file .env ghcr.io/alegerber/folio:latest
 
 See [`.plans/PLAN.md`](.plans/PLAN.md) for the full feature roadmap.
 
-Release automation and GHCR publishing are in place. Planned features (in order): URL rendering → Screenshot API → OpenAPI docs → LibreOffice conversion → Async webhooks → Queue-based scaling.
+Release automation and GHCR publishing are in place. Planned features (in order): Screenshot API → OpenAPI docs → LibreOffice conversion → Async webhooks → Queue-based scaling.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "folio",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "folio",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.600.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "folio",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PDF generation microservice using Puppeteer, Fastify, and S3",
   "license": "MIT",
   "repository": {

--- a/scripts/aws-setup.sh
+++ b/scripts/aws-setup.sh
@@ -209,7 +209,7 @@ JSON
       "Effect": "Allow",
       "Action": "cloudformation:*",
       "Resource": [
-        "arn:aws:cloudformation:${REGION}:${AWS_ACCOUNT_ID}:stack/folio/*",
+        "arn:aws:cloudformation:${REGION}:${AWS_ACCOUNT_ID}:stack/folio*/*",
         "arn:aws:cloudformation:${REGION}:aws:transform/Serverless-2016-10-31"
       ]
     },

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -421,6 +421,58 @@ assert_eq "HTTP 400" "400" "$HTTP_CODE"
 
 echo ""
 
+# ── SSRF protection: private/loopback IPs → 400 ─────────────────────────────
+
+echo "--- SSRF: loopback IP (127.0.0.1) → 400 ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "http://127.0.0.1/"}')
+assert_eq "HTTP 400 (loopback)" "400" "$HTTP_CODE"
+
+echo "--- SSRF: RFC1918 class A (10.0.0.1) → 400 ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "http://10.0.0.1/"}')
+assert_eq "HTTP 400 (RFC1918 10.x)" "400" "$HTTP_CODE"
+
+echo "--- SSRF: RFC1918 class C (192.168.1.1) → 400 ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "http://192.168.1.1/"}')
+assert_eq "HTTP 400 (RFC1918 192.168.x)" "400" "$HTTP_CODE"
+
+echo "--- SSRF: link-local / EC2 metadata (169.254.169.254) → 400 ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "http://169.254.169.254/latest/meta-data/"}')
+assert_eq "HTTP 400 (link-local)" "400" "$HTTP_CODE"
+
+echo "--- SSRF: localhost hostname → 400 ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "http://localhost/"}')
+assert_eq "HTTP 400 (localhost)" "400" "$HTTP_CODE"
+
+echo "--- SSRF: non-HTTP scheme (file://) → 400 ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "file:///etc/passwd"}')
+assert_eq "HTTP 400 (file://)" "400" "$HTTP_CODE"
+
+SSRF_RESP=$(curl -s -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "http://169.254.169.254/latest/meta-data/"}')
+assert_contains "SSRF error body contains error field" '"error"' "$SSRF_RESP"
+
+echo ""
+
 # ── Cleanup URL-generated PDF ────────────────────────────────────────────────
 
 if [ -n "$URL_ID" ]; then

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -334,6 +334,99 @@ else
   echo ""
 fi
 
+# ── POST /pdf/generate with url field ────────────────────────────────────────
+
+echo "--- POST /pdf/generate (url, stream: false) ---"
+RESP=$(curl -s -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com"}')
+
+STATUS_CODE=$(echo "$RESP" | grep -o '"statusCode":[0-9]*' | grep -o '[0-9]*')
+assert_eq "statusCode 200" "200" "$STATUS_CODE"
+assert_contains "response contains url" '"url"' "$RESP"
+
+URL_ID=$(extract_json_string "$RESP" id)
+echo "    URL ID: $URL_ID"
+
+echo ""
+
+# ── POST /pdf/generate with url + cookies/headers ───────────────────────────
+
+echo "--- POST /pdf/generate (url + cookies + extraHeaders) ---"
+RESP=$(curl -s -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{
+    "url": "https://example.com",
+    "cookies": [{"name": "test", "value": "abc", "domain": "example.com"}],
+    "extraHeaders": {"X-Custom": "smoke"}
+  }')
+STATUS_CODE=$(echo "$RESP" | grep -o '"statusCode":[0-9]*' | grep -o '[0-9]*')
+assert_eq "statusCode 200" "200" "$STATUS_CODE"
+
+echo ""
+
+# ── POST /pdf/generate with url (stream: true) ──────────────────────────────
+
+echo "--- POST /pdf/generate (url, stream: true) ---"
+TMP_URL_PDF=$(mktemp /tmp/smoke-test-url-XXXXXX.pdf)
+HTTP_CODE=$(curl -s -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com", "stream": true}' \
+  -o "$TMP_URL_PDF" -w "%{http_code}")
+assert_eq "HTTP 200" "200" "$HTTP_CODE"
+
+MAGIC=$(head -c 4 "$TMP_URL_PDF" 2>/dev/null || true)
+if [ "$MAGIC" = "%PDF" ]; then
+  ok "url response is a valid PDF"
+else
+  fail "url response is not a valid PDF (magic bytes: $MAGIC)"
+fi
+rm -f "$TMP_URL_PDF"
+
+echo ""
+
+# ── POST /pdf/generate validation: both html + url → 400 ────────────────────
+
+echo "--- POST /pdf/generate (html + url → 400) ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"html": "<h1>test</h1>", "url": "https://example.com"}')
+assert_eq "HTTP 400" "400" "$HTTP_CODE"
+
+echo ""
+
+# ── POST /pdf/generate validation: neither html nor url → 400 ───────────────
+
+echo "--- POST /pdf/generate (no html, no url → 400) ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{}')
+assert_eq "HTTP 400" "400" "$HTTP_CODE"
+
+echo ""
+
+# ── POST /pdf/generate validation: invalid url → 400 ────────────────────────
+
+echo "--- POST /pdf/generate (invalid url → 400) ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/pdf/generate" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"url": "not-a-url"}')
+assert_eq "HTTP 400" "400" "$HTTP_CODE"
+
+echo ""
+
+# ── Cleanup URL-generated PDF ────────────────────────────────────────────────
+
+if [ -n "$URL_ID" ]; then
+  curl -s -o /dev/null -X DELETE "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}" "$BASE/pdf/$URL_ID"
+fi
+
 # ── DELETE /pdf/:id ───────────────────────────────────────────────────────────
 
 echo "--- DELETE /pdf/:id ---"

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -12,6 +12,7 @@ const envSchema = z.object({
   PORT: z.coerce.number().int().positive().default(8080),
   API_KEY: z.string().min(32).optional(),
   GHOSTSCRIPT_PATH: z.string().optional(),
+  SSRF_PROTECTION: z.string().optional().transform((v) => v !== 'false'),
 });
 
 export type Env = z.infer<typeof envSchema>;

--- a/src/routes/pdf/handler.ts
+++ b/src/routes/pdf/handler.ts
@@ -12,6 +12,8 @@ import type { PdfService } from '../../services/pdf/PdfService.js';
 import type { StorageService, StoredPdf } from '../../services/storage/StorageService.js';
 import type { MetricsService } from '../../services/metrics/MetricsService.js';
 import type { PdfOperationsService } from '../../services/pdf/PdfOperationsService.js';
+import { assertSafeUrl, SsrfError } from '../../utils/ssrf.js';
+import { env } from '../../config/env.js';
 
 function sendStoredPdf(reply: FastifyReply, storedPdf: StoredPdf) {
   return reply.send({ statusCode: 200, data: storedPdf });
@@ -141,6 +143,17 @@ export function createGenerateHandler(
     }
     if (generateInput.html && generateInput.url) {
       return reply.badRequest('Provide either html or url, not both');
+    }
+
+    if (generateInput.url && env.SSRF_PROTECTION) {
+      try {
+        await assertSafeUrl(generateInput.url);
+      } catch (err) {
+        if (err instanceof SsrfError) {
+          return reply.status(400).send({ statusCode: 400, error: err.message });
+        }
+        throw err;
+      }
     }
 
     const start = Date.now();

--- a/src/routes/pdf/handler.ts
+++ b/src/routes/pdf/handler.ts
@@ -134,11 +134,19 @@ export function createGenerateHandler(
     request: FastifyRequest<{ Body: GenerateRequestInput }>,
     reply: FastifyReply,
   ) {
-    const { html, css, paper, options, stream } = request.body;
+    const { stream, ...generateInput } = request.body;
+
+    if (!generateInput.html && !generateInput.url) {
+      return reply.badRequest('Provide either html or url');
+    }
+    if (generateInput.html && generateInput.url) {
+      return reply.badRequest('Provide either html or url, not both');
+    }
+
     const start = Date.now();
 
     try {
-      const pdfBuffer = await pdfService.generate(html, css, paper, options);
+      const pdfBuffer = await pdfService.generate(generateInput);
 
       if (stream) {
         metricsService.recordSuccess(Date.now() - start, pdfBuffer.length);

--- a/src/routes/pdf/schema.ts
+++ b/src/routes/pdf/schema.ts
@@ -3,7 +3,8 @@ import { z } from 'zod';
 export const MAX_MERGE_IDS = 20;
 
 export const generateRequestSchema = z.object({
-  html: z.string().min(1, 'html is required'),
+  html: z.string().min(1).optional(),
+  url: z.url().optional(),
   css: z.string().optional(),
   paper: z
     .object({
@@ -27,6 +28,16 @@ export const generateRequestSchema = z.object({
       footerTemplate: z.string().optional(),
     })
     .optional(),
+  cookies: z
+    .array(
+      z.object({
+        name: z.string(),
+        value: z.string(),
+        domain: z.string(),
+      }),
+    )
+    .optional(),
+  extraHeaders: z.record(z.string(), z.string()).optional(),
   stream: z.boolean().optional().default(false),
 });
 

--- a/src/routes/screenshot/handler.ts
+++ b/src/routes/screenshot/handler.ts
@@ -1,0 +1,49 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { ScreenshotRequestInput } from './schema.js';
+import type { ScreenshotService } from '../../services/screenshot/ScreenshotService.js';
+import type { StorageService } from '../../services/storage/StorageService.js';
+import { assertSafeUrl, SsrfError } from '../../utils/ssrf.js';
+import { env } from '../../config/env.js';
+
+export function createScreenshotHandler(
+  screenshotService: ScreenshotService,
+  storageService: StorageService,
+) {
+  return async function screenshotHandler(
+    request: FastifyRequest<{ Body: ScreenshotRequestInput }>,
+    reply: FastifyReply,
+  ) {
+    const { stream, ...captureInput } = request.body;
+
+    if (!captureInput.html && !captureInput.url) {
+      return reply.badRequest('Provide either html or url');
+    }
+    if (captureInput.html && captureInput.url) {
+      return reply.badRequest('Provide either html or url, not both');
+    }
+
+    if (captureInput.url && env.SSRF_PROTECTION) {
+      try {
+        await assertSafeUrl(captureInput.url);
+      } catch (err) {
+        if (err instanceof SsrfError) {
+          return reply.status(400).send({ statusCode: 400, error: err.message });
+        }
+        throw err;
+      }
+    }
+
+    const { buffer, mimeType } = await screenshotService.capture(captureInput);
+    const format = captureInput.format ?? 'png';
+
+    if (stream) {
+      return reply
+        .header('Content-Type', mimeType)
+        .header('Content-Disposition', `attachment; filename="screenshot.${format}"`)
+        .send(buffer);
+    }
+
+    const stored = await storageService.uploadImage(buffer, format, mimeType);
+    return reply.send({ statusCode: 200, data: { url: stored.url } });
+  };
+}

--- a/src/routes/screenshot/index.ts
+++ b/src/routes/screenshot/index.ts
@@ -1,0 +1,20 @@
+import type { FastifyPluginAsync } from 'fastify';
+import { screenshotRequestJsonSchema } from './schema.js';
+import { createScreenshotHandler } from './handler.js';
+import type { ScreenshotService } from '../../services/screenshot/ScreenshotService.js';
+import type { StorageService } from '../../services/storage/StorageService.js';
+
+interface ScreenshotRouteOptions {
+  screenshotService: ScreenshotService;
+  storageService: StorageService;
+}
+
+export const screenshotRoutes: FastifyPluginAsync<ScreenshotRouteOptions> = async (
+  fastify,
+  { screenshotService, storageService },
+) => {
+  fastify.post('/screenshot', {
+    schema: { body: screenshotRequestJsonSchema },
+    handler: createScreenshotHandler(screenshotService, storageService),
+  });
+};

--- a/src/routes/screenshot/schema.ts
+++ b/src/routes/screenshot/schema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const screenshotRequestSchema = z.object({
+  html: z.string().min(1).optional(),
+  url: z.url().optional(),
+  css: z.string().optional(),
+  viewport: z
+    .object({
+      width: z.number().int().min(1).max(3840).default(1280),
+      height: z.number().int().min(1).max(2160).default(720),
+    })
+    .optional(),
+  format: z.enum(['png', 'jpeg', 'webp']).default('png'),
+  quality: z.number().int().min(1).max(100).optional(),
+  fullPage: z.boolean().default(false),
+  clip: z
+    .object({
+      x: z.number(),
+      y: z.number(),
+      width: z.number().positive(),
+      height: z.number().positive(),
+    })
+    .optional(),
+  stream: z.boolean().default(false),
+});
+
+export type ScreenshotRequestInput = z.infer<typeof screenshotRequestSchema>;
+
+const { $schema: _$schema, ...screenshotRequestJsonSchema } = z.toJSONSchema(screenshotRequestSchema);
+export { screenshotRequestJsonSchema };

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,10 +6,12 @@ import { sensiblePlugin } from './plugins/sensible.js';
 import { healthRoutes } from './routes/health/index.js';
 import { pdfRoutes } from './routes/pdf/index.js';
 import { metricsRoutes } from './routes/metrics/index.js';
+import { screenshotRoutes } from './routes/screenshot/index.js';
 import { PdfService } from './services/pdf/PdfService.js';
 import { PdfOperationsService } from './services/pdf/PdfOperationsService.js';
 import { StorageService } from './services/storage/StorageService.js';
 import { MetricsService } from './services/metrics/MetricsService.js';
+import { ScreenshotService } from './services/screenshot/ScreenshotService.js';
 
 export async function buildApp() {
   const fastify = Fastify({
@@ -25,6 +27,7 @@ export async function buildApp() {
   const pdfService = new PdfService();
   const metricsService = new MetricsService();
   const opsService = new PdfOperationsService(env.GHOSTSCRIPT_PATH);
+  const screenshotService = new ScreenshotService(pdfService);
 
   await fastify.register(sensiblePlugin);
   await fastify.register(authPlugin);
@@ -37,6 +40,10 @@ export async function buildApp() {
     opsService,
   });
   await fastify.register(metricsRoutes, { metricsService });
+  await fastify.register(screenshotRoutes, {
+    screenshotService,
+    storageService: new StorageService(fastify.s3, fastify.s3Public),
+  });
 
   fastify.addHook('onReady', async () => {
     // Warm up the browser in the background — don't block the hook since

--- a/src/services/pdf/PdfService.test.ts
+++ b/src/services/pdf/PdfService.test.ts
@@ -4,10 +4,16 @@ import { PdfService } from './PdfService.js';
 const mockPdf = vi.fn().mockResolvedValue(Buffer.from('%PDF-1.4 mock'));
 const mockClose = vi.fn().mockResolvedValue(undefined);
 const mockSetContent = vi.fn().mockResolvedValue(undefined);
+const mockGoto = vi.fn().mockResolvedValue(undefined);
 const mockAddStyleTag = vi.fn().mockResolvedValue(undefined);
+const mockSetCookie = vi.fn().mockResolvedValue(undefined);
+const mockSetExtraHTTPHeaders = vi.fn().mockResolvedValue(undefined);
 const mockNewPage = vi.fn().mockResolvedValue({
   setContent: mockSetContent,
+  goto: mockGoto,
   addStyleTag: mockAddStyleTag,
+  setCookie: mockSetCookie,
+  setExtraHTTPHeaders: mockSetExtraHTTPHeaders,
   pdf: mockPdf,
   close: mockClose,
 });
@@ -42,26 +48,61 @@ describe('PdfService', () => {
   it('generates a PDF from HTML', async () => {
     const html = '<html><body><h1>Hello World</h1></body></html>';
 
-    const result = await pdfService.generate(html);
+    const result = await pdfService.generate({ html });
 
     expect(mockSetContent).toHaveBeenCalledWith(html, { waitUntil: 'networkidle0' });
+    expect(mockGoto).not.toHaveBeenCalled();
     expect(mockAddStyleTag).not.toHaveBeenCalled();
     expect(mockPdf).toHaveBeenCalledOnce();
     expect(result).toBeInstanceOf(Buffer);
+  });
+
+  it('navigates to a URL when url is provided', async () => {
+    const url = 'https://example.com';
+
+    const result = await pdfService.generate({ url });
+
+    expect(mockGoto).toHaveBeenCalledWith(url, { waitUntil: 'networkidle0', timeout: 25_000 });
+    expect(mockSetContent).not.toHaveBeenCalled();
+    expect(mockPdf).toHaveBeenCalledOnce();
+    expect(result).toBeInstanceOf(Buffer);
+  });
+
+  it('sets cookies before navigation', async () => {
+    const cookies = [{ name: 'session', value: 'abc123', domain: 'example.com' }];
+
+    await pdfService.generate({ url: 'https://example.com', cookies });
+
+    expect(mockSetCookie).toHaveBeenCalledWith(...cookies);
+    // cookies set before goto
+    const setCookieOrder = mockSetCookie.mock.invocationCallOrder[0];
+    const gotoOrder = mockGoto.mock.invocationCallOrder[0];
+    expect(setCookieOrder).toBeLessThan(gotoOrder);
+  });
+
+  it('sets extra headers before navigation', async () => {
+    const extraHeaders = { Authorization: 'Bearer token123' };
+
+    await pdfService.generate({ url: 'https://example.com', extraHeaders });
+
+    expect(mockSetExtraHTTPHeaders).toHaveBeenCalledWith(extraHeaders);
+    const headersOrder = mockSetExtraHTTPHeaders.mock.invocationCallOrder[0];
+    const gotoOrder = mockGoto.mock.invocationCallOrder[0];
+    expect(headersOrder).toBeLessThan(gotoOrder);
   });
 
   it('injects CSS via addStyleTag when css is provided', async () => {
     const html = '<html><body><h1>Hello</h1></body></html>';
     const css = 'body { font-size: 14px; }';
 
-    await pdfService.generate(html, css);
+    await pdfService.generate({ html, css });
 
     expect(mockSetContent).toHaveBeenCalledWith(html, { waitUntil: 'networkidle0' });
     expect(mockAddStyleTag).toHaveBeenCalledWith({ content: css });
   });
 
   it('does not call addStyleTag when css is not provided', async () => {
-    await pdfService.generate('<html></html>');
+    await pdfService.generate({ html: '<html></html>' });
 
     expect(mockAddStyleTag).not.toHaveBeenCalled();
   });
@@ -69,7 +110,7 @@ describe('PdfService', () => {
   it('applies paper size options', async () => {
     const html = '<html><body></body></html>';
 
-    await pdfService.generate(html, undefined, { size: 'A4', orientation: 'portrait' });
+    await pdfService.generate({ html, paper: { size: 'A4', orientation: 'portrait' } });
 
     const pdfCall = mockPdf.mock.calls[0][0];
     expect(pdfCall).toMatchObject({ width: '210mm', height: '297mm' });
@@ -78,7 +119,7 @@ describe('PdfService', () => {
   it('applies landscape orientation by swapping dimensions', async () => {
     const html = '<html><body></body></html>';
 
-    await pdfService.generate(html, undefined, { size: 'A4', orientation: 'landscape' });
+    await pdfService.generate({ html, paper: { size: 'A4', orientation: 'landscape' } });
 
     const pdfCall = mockPdf.mock.calls[0][0];
     expect(pdfCall).toMatchObject({ width: '297mm', height: '210mm' });
@@ -87,16 +128,14 @@ describe('PdfService', () => {
   it('applies PDF options', async () => {
     const html = '<html><body></body></html>';
 
-    await pdfService.generate(
+    await pdfService.generate({
       html,
-      undefined,
-      undefined,
-      {
+      options: {
         printBackground: true,
         scale: 0.8,
         margin: { top: '10mm', bottom: '10mm', left: '15mm', right: '15mm' },
       },
-    );
+    });
 
     const pdfCall = mockPdf.mock.calls[0][0];
     expect(pdfCall).toMatchObject({
@@ -109,21 +148,21 @@ describe('PdfService', () => {
   it('closes the page after generation even on error', async () => {
     mockSetContent.mockRejectedValueOnce(new Error('Page load failed'));
 
-    await expect(pdfService.generate('<html></html>')).rejects.toThrow('Page load failed');
+    await expect(pdfService.generate({ html: '<html></html>' })).rejects.toThrow('Page load failed');
     expect(mockClose).toHaveBeenCalledOnce();
   });
 
   it('reuses the browser across multiple calls', async () => {
     const html = '<html><body></body></html>';
 
-    await pdfService.generate(html);
-    await pdfService.generate(html);
+    await pdfService.generate({ html });
+    await pdfService.generate({ html });
 
     expect(mockLaunch).toHaveBeenCalledOnce();
   });
 
   it('closes the browser on close()', async () => {
-    await pdfService.generate('<html></html>');
+    await pdfService.generate({ html: '<html></html>' });
     await pdfService.close();
 
     expect(mockBrowserClose).toHaveBeenCalledOnce();
@@ -137,8 +176,8 @@ describe('PdfService', () => {
         close: mockBrowserClose,
       });
 
-    await expect(pdfService.generate('<html></html>')).rejects.toThrow('Chromium failed to start');
-    await expect(pdfService.generate('<html></html>')).resolves.toBeInstanceOf(Buffer);
+    await expect(pdfService.generate({ html: '<html></html>' })).rejects.toThrow('Chromium failed to start');
+    await expect(pdfService.generate({ html: '<html></html>' })).resolves.toBeInstanceOf(Buffer);
     expect(mockLaunch).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/services/pdf/PdfService.ts
+++ b/src/services/pdf/PdfService.ts
@@ -1,5 +1,15 @@
 import type { Browser, PaperFormat } from 'puppeteer-core';
-import type { PaperOptions, PdfOptions } from '../../types/index.js';
+import type { PaperOptions, PdfOptions, CookieParam } from '../../types/index.js';
+
+export interface GenerateInput {
+  html?: string;
+  url?: string;
+  css?: string;
+  paper?: PaperOptions;
+  options?: PdfOptions;
+  cookies?: CookieParam[];
+  extraHeaders?: Record<string, string>;
+}
 
 const PAPER_SIZES: Record<string, { width: string; height: string }> = {
   A4: { width: '210mm', height: '297mm' },
@@ -34,17 +44,24 @@ export class PdfService {
     });
   }
 
-  async generate(
-    html: string,
-    css?: string,
-    paper?: PaperOptions,
-    options?: PdfOptions,
-  ): Promise<Buffer> {
+  async generate(input: GenerateInput): Promise<Buffer> {
+    const { html, url, css, paper, options, cookies, extraHeaders } = input;
     const browser = await this.getBrowser();
     const page = await browser.newPage();
 
     try {
-      await page.setContent(html, { waitUntil: 'networkidle0' });
+      if (cookies?.length) {
+        await page.setCookie(...cookies);
+      }
+      if (extraHeaders) {
+        await page.setExtraHTTPHeaders(extraHeaders);
+      }
+
+      if (url) {
+        await page.goto(url, { waitUntil: 'networkidle0', timeout: 25_000 });
+      } else {
+        await page.setContent(html!, { waitUntil: 'networkidle0' });
+      }
 
       if (css) {
         await page.addStyleTag({ content: css });

--- a/src/services/screenshot/ScreenshotService.test.ts
+++ b/src/services/screenshot/ScreenshotService.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ScreenshotService } from './ScreenshotService.js';
+import type { PdfService } from '../pdf/PdfService.js';
+
+const mockScreenshot = vi.fn().mockResolvedValue(Buffer.from('PNG_DATA'));
+const mockPageClose = vi.fn().mockResolvedValue(undefined);
+const mockSetContent = vi.fn().mockResolvedValue(undefined);
+const mockGoto = vi.fn().mockResolvedValue(undefined);
+const mockAddStyleTag = vi.fn().mockResolvedValue(undefined);
+const mockSetViewport = vi.fn().mockResolvedValue(undefined);
+
+const mockNewPage = vi.fn().mockResolvedValue({
+  setViewport: mockSetViewport,
+  setContent: mockSetContent,
+  goto: mockGoto,
+  addStyleTag: mockAddStyleTag,
+  screenshot: mockScreenshot,
+  close: mockPageClose,
+});
+
+const mockBrowser = { newPage: mockNewPage };
+const mockGetBrowser = vi.fn().mockResolvedValue(mockBrowser);
+const mockPdfService = { getBrowser: mockGetBrowser } as unknown as PdfService;
+
+describe('ScreenshotService', () => {
+  let screenshotService: ScreenshotService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    screenshotService = new ScreenshotService(mockPdfService);
+  });
+
+  it('captures a PNG screenshot from HTML', async () => {
+    const { buffer, mimeType } = await screenshotService.capture({
+      html: '<html><body>Hello</body></html>',
+    });
+
+    expect(mockSetContent).toHaveBeenCalledWith('<html><body>Hello</body></html>', {
+      waitUntil: 'networkidle0',
+    });
+    expect(mockGoto).not.toHaveBeenCalled();
+    expect(mockScreenshot).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'png', fullPage: false }),
+    );
+    expect(mimeType).toBe('image/png');
+    expect(buffer).toBeInstanceOf(Buffer);
+  });
+
+  it('navigates to a URL when url is provided', async () => {
+    await screenshotService.capture({ url: 'https://example.com' });
+
+    expect(mockGoto).toHaveBeenCalledWith('https://example.com', {
+      waitUntil: 'networkidle0',
+      timeout: 25_000,
+    });
+    expect(mockSetContent).not.toHaveBeenCalled();
+  });
+
+  it('injects CSS when css is provided', async () => {
+    await screenshotService.capture({
+      html: '<html></html>',
+      css: 'body { background: red; }',
+    });
+
+    expect(mockAddStyleTag).toHaveBeenCalledWith({ content: 'body { background: red; }' });
+  });
+
+  it('does not call addStyleTag when css is not provided', async () => {
+    await screenshotService.capture({ html: '<html></html>' });
+
+    expect(mockAddStyleTag).not.toHaveBeenCalled();
+  });
+
+  it('uses custom viewport when provided', async () => {
+    await screenshotService.capture({
+      html: '<html></html>',
+      viewport: { width: 800, height: 600 },
+    });
+
+    expect(mockSetViewport).toHaveBeenCalledWith({ width: 800, height: 600 });
+  });
+
+  it('defaults to 1280x720 viewport', async () => {
+    await screenshotService.capture({ html: '<html></html>' });
+
+    expect(mockSetViewport).toHaveBeenCalledWith({ width: 1280, height: 720 });
+  });
+
+  it('captures JPEG with quality', async () => {
+    const { mimeType } = await screenshotService.capture({
+      html: '<html></html>',
+      format: 'jpeg',
+      quality: 80,
+    });
+
+    expect(mockScreenshot).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'jpeg', quality: 80 }),
+    );
+    expect(mimeType).toBe('image/jpeg');
+  });
+
+  it('ignores quality for PNG', async () => {
+    await screenshotService.capture({
+      html: '<html></html>',
+      format: 'png',
+      quality: 80,
+    });
+
+    const screenshotCall = mockScreenshot.mock.calls[0][0];
+    expect(screenshotCall.quality).toBeUndefined();
+  });
+
+  it('captures full page when fullPage is true', async () => {
+    await screenshotService.capture({ html: '<html></html>', fullPage: true });
+
+    expect(mockScreenshot).toHaveBeenCalledWith(expect.objectContaining({ fullPage: true }));
+  });
+
+  it('applies clip region when provided', async () => {
+    const clip = { x: 0, y: 0, width: 400, height: 300 };
+
+    await screenshotService.capture({ html: '<html></html>', clip });
+
+    expect(mockScreenshot).toHaveBeenCalledWith(expect.objectContaining({ clip }));
+  });
+
+  it('closes the page after capture even on error', async () => {
+    mockSetContent.mockRejectedValueOnce(new Error('Load failed'));
+
+    await expect(
+      screenshotService.capture({ html: '<html></html>' }),
+    ).rejects.toThrow('Load failed');
+
+    expect(mockPageClose).toHaveBeenCalledOnce();
+  });
+
+  it('reuses the browser from PdfService', async () => {
+    await screenshotService.capture({ html: '<html></html>' });
+    await screenshotService.capture({ html: '<html></html>' });
+
+    expect(mockGetBrowser).toHaveBeenCalledTimes(2);
+    expect(mockNewPage).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/screenshot/ScreenshotService.ts
+++ b/src/services/screenshot/ScreenshotService.ts
@@ -1,0 +1,39 @@
+import type { PdfService } from '../pdf/PdfService.js';
+import type { ScreenshotRequest } from '../../types/index.js';
+
+export class ScreenshotService {
+  constructor(private readonly pdfService: PdfService) {}
+
+  async capture(request: ScreenshotRequest): Promise<{ buffer: Buffer; mimeType: string }> {
+    const format = request.format ?? 'png';
+    const browser = await this.pdfService.getBrowser();
+    const page = await browser.newPage();
+
+    try {
+      await page.setViewport(request.viewport ?? { width: 1280, height: 720 });
+
+      if (request.url) {
+        await page.goto(request.url, { waitUntil: 'networkidle0', timeout: 25_000 });
+      } else {
+        await page.setContent(request.html!, { waitUntil: 'networkidle0' });
+      }
+
+      if (request.css) {
+        await page.addStyleTag({ content: request.css });
+      }
+
+      const buffer = Buffer.from(
+        await page.screenshot({
+          type: format,
+          quality: format === 'png' ? undefined : request.quality,
+          fullPage: request.fullPage ?? false,
+          clip: request.clip,
+        }),
+      );
+
+      return { buffer, mimeType: `image/${format}` };
+    } finally {
+      await page.close();
+    }
+  }
+}

--- a/src/services/storage/StorageService.ts
+++ b/src/services/storage/StorageService.ts
@@ -119,4 +119,29 @@ export class StorageService {
 
     return { id, url };
   }
+
+  async uploadImage(buffer: Buffer, format: string, contentType: string): Promise<StoredPdf> {
+    const id = randomUUID();
+    const key = `screenshots/${id}.${format}`;
+
+    await this.s3.send(
+      new PutObjectCommand({
+        Bucket: env.S3_BUCKET,
+        Key: key,
+        Body: buffer,
+        ContentType: contentType,
+      }),
+    );
+
+    const url = await getSignedUrl(
+      this.s3Public,
+      new GetObjectCommand({
+        Bucket: env.S3_BUCKET,
+        Key: key,
+      }),
+      { expiresIn: env.SIGNED_URL_EXPIRY_SECONDS },
+    );
+
+    return { id, url };
+  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,11 +18,20 @@ export interface PdfOptions {
   footerTemplate?: string;
 }
 
+export interface CookieParam {
+  name: string;
+  value: string;
+  domain: string;
+}
+
 export interface GenerateRequest {
-  html: string;
+  html?: string;
+  url?: string;
   css?: string;
   paper?: PaperOptions;
   options?: PdfOptions;
+  cookies?: CookieParam[];
+  extraHeaders?: Record<string, string>;
   stream?: boolean;
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,3 +42,22 @@ export interface GenerateResponse {
     url: string;
   };
 }
+
+export interface ScreenshotRequest {
+  html?: string;
+  url?: string;
+  css?: string;
+  viewport?: { width: number; height: number };
+  format?: 'png' | 'jpeg' | 'webp';
+  quality?: number;
+  fullPage?: boolean;
+  clip?: { x: number; y: number; width: number; height: number };
+  stream?: boolean;
+}
+
+export interface ScreenshotResponse {
+  statusCode: number;
+  data: {
+    url: string;
+  };
+}

--- a/src/utils/ssrf.test.ts
+++ b/src/utils/ssrf.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { assertSafeUrl, SsrfError } from './ssrf.js';
+
+vi.mock('dns/promises', () => ({
+  lookup: vi.fn(),
+}));
+
+import { lookup } from 'dns/promises';
+const mockLookup = vi.mocked(lookup);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('assertSafeUrl — scheme checks', () => {
+  it('allows http scheme', async () => {
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    await expect(assertSafeUrl('http://example.com')).resolves.toBeUndefined();
+  });
+
+  it('allows https scheme', async () => {
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    await expect(assertSafeUrl('https://example.com')).resolves.toBeUndefined();
+  });
+
+  it('blocks file:// scheme', async () => {
+    await expect(assertSafeUrl('file:///etc/passwd')).rejects.toThrow(SsrfError);
+    await expect(assertSafeUrl('file:///etc/passwd')).rejects.toThrow('"file:" is not allowed');
+  });
+
+  it('blocks ftp:// scheme', async () => {
+    await expect(assertSafeUrl('ftp://example.com/file')).rejects.toThrow(SsrfError);
+  });
+
+  it('blocks data:// scheme', async () => {
+    await expect(assertSafeUrl('data:text/html,<h1>hi</h1>')).rejects.toThrow(SsrfError);
+  });
+});
+
+describe('assertSafeUrl — private IP ranges blocked', () => {
+  const privateIps = [
+    ['10.0.0.1', 'RFC1918 class A'],
+    ['10.255.255.255', 'RFC1918 class A edge'],
+    ['172.16.0.1', 'RFC1918 class B low'],
+    ['172.31.255.255', 'RFC1918 class B high'],
+    ['192.168.0.1', 'RFC1918 class C'],
+    ['127.0.0.1', 'loopback'],
+    ['127.0.0.2', 'loopback range'],
+    ['169.254.169.254', 'link-local / EC2 metadata'],
+    ['169.254.0.1', 'link-local range'],
+    ['::1', 'IPv6 loopback'],
+    ['fc00::1', 'IPv6 ULA'],
+    ['fe80::1', 'IPv6 link-local'],
+  ] as const;
+
+  for (const [ip, label] of privateIps) {
+    it(`blocks ${label} (${ip}) when given directly`, async () => {
+      await expect(assertSafeUrl(`http://${ip.includes(':') ? `[${ip}]` : ip}/path`)).rejects.toThrow(SsrfError);
+    });
+  }
+
+  it('blocks private IP resolved from hostname', async () => {
+    mockLookup.mockResolvedValue({ address: '10.0.0.1', family: 4 });
+    await expect(assertSafeUrl('http://internal.example.com')).rejects.toThrow(SsrfError);
+  });
+
+  it('includes the resolved IP in the error message', async () => {
+    mockLookup.mockResolvedValue({ address: '192.168.1.100', family: 4 });
+    await expect(assertSafeUrl('http://evil.example.com')).rejects.toThrow('192.168.1.100');
+  });
+});
+
+describe('assertSafeUrl — public IPs allowed', () => {
+  const publicIps = ['8.8.8.8', '93.184.216.34', '1.1.1.1', '172.15.255.255', '172.32.0.0'];
+
+  for (const ip of publicIps) {
+    it(`allows public IP ${ip}`, async () => {
+      await expect(assertSafeUrl(`http://${ip}/`)).resolves.toBeUndefined();
+    });
+  }
+
+  it('allows public hostname resolving to public IP', async () => {
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    await expect(assertSafeUrl('https://example.com')).resolves.toBeUndefined();
+  });
+});
+
+describe('assertSafeUrl — hostname resolution', () => {
+  it('calls lookup for non-IP hostnames', async () => {
+    mockLookup.mockResolvedValue({ address: '93.184.216.34', family: 4 });
+    await assertSafeUrl('https://example.com/path?q=1');
+    expect(mockLookup).toHaveBeenCalledWith('example.com', { verbatim: true });
+  });
+
+  it('does not call lookup for IP hostnames', async () => {
+    await assertSafeUrl('https://93.184.216.34/');
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it('propagates DNS lookup errors', async () => {
+    mockLookup.mockRejectedValue(new Error('ENOTFOUND'));
+    await expect(assertSafeUrl('https://does-not-exist.invalid')).rejects.toThrow('ENOTFOUND');
+  });
+});

--- a/src/utils/ssrf.ts
+++ b/src/utils/ssrf.ts
@@ -1,0 +1,49 @@
+import { isIP } from 'net';
+import { lookup } from 'dns/promises';
+
+const BLOCKED_RANGES = [
+  /^10\./,
+  /^172\.(1[6-9]|2\d|3[01])\./,
+  /^192\.168\./,
+  /^127\./,
+  /^169\.254\./,
+  /^::1$/,
+  /^fc00:/,
+  /^fe80:/,
+];
+
+export async function assertSafeUrl(rawUrl: string): Promise<void> {
+  const parsed = new URL(rawUrl);
+
+  if (!['http:', 'https:'].includes(parsed.protocol)) {
+    throw new SsrfError(`Scheme "${parsed.protocol}" is not allowed`);
+  }
+
+  // URL spec wraps IPv6 literals in brackets: "[::1]" — strip them before isIP/lookup
+  const rawHostname = parsed.hostname;
+  const hostname =
+    rawHostname.startsWith('[') && rawHostname.endsWith(']')
+      ? rawHostname.slice(1, -1)
+      : rawHostname;
+  let ip: string;
+
+  if (isIP(hostname)) {
+    ip = hostname;
+  } else {
+    const result = await lookup(hostname, { verbatim: true });
+    ip = result.address;
+  }
+
+  for (const range of BLOCKED_RANGES) {
+    if (range.test(ip)) {
+      throw new SsrfError(`URL resolves to a private address (${ip})`);
+    }
+  }
+}
+
+export class SsrfError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SsrfError';
+  }
+}

--- a/test/integration/generate.test.ts
+++ b/test/integration/generate.test.ts
@@ -181,4 +181,60 @@ describe('POST /pdf/generate', () => {
 
     expect(response.statusCode).toBe(200);
   });
+
+  it('accepts a url field instead of html', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      payload: {
+        url: 'https://example.com',
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+    const body = response.json();
+    expect(body).toMatchObject({
+      statusCode: 200,
+      data: STORED_PDF,
+    });
+  });
+
+  it('accepts url with cookies and extraHeaders', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      payload: {
+        url: 'https://example.com',
+        cookies: [{ name: 'session', value: 'abc', domain: 'example.com' }],
+        extraHeaders: { Authorization: 'Bearer token' },
+      },
+    });
+
+    expect(response.statusCode).toBe(200);
+  });
+
+  it('returns 400 when both html and url are provided', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      payload: {
+        html: '<html></html>',
+        url: 'https://example.com',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
+
+  it('returns 400 for invalid url', async () => {
+    const response = await app.inject({
+      method: 'POST',
+      url: '/pdf/generate',
+      payload: {
+        url: 'not-a-url',
+      },
+    });
+
+    expect(response.statusCode).toBe(400);
+  });
 });


### PR DESCRIPTION
## Summary

Release v1.1.0 with the following changes:

### Features
- **URL rendering for PDF generation:** `POST /pdf/generate` now accepts a `url` field as an alternative to `html`. Puppeteer navigates to the URL and renders the page as PDF, with support for optional cookies and HTTP headers for authenticated pages.
- **Screenshot API:** New `POST /screenshot` endpoint – renders HTML or a URL via Puppeteer and returns PNG/JPEG/WebP. Supports stream mode (binary response) and S3 storage, viewport configuration, clip regions, fullPage, and quality parameters.
- **SSRF protection:** Blocks requests to private/loopback IP ranges and non-HTTP(S) schemes before Puppeteer loads any URL. Covers EC2 metadata (169.254.x), RFC1918, loopback, and IPv6 private ranges.

### CI/CD
- Deploy workflow now triggers on `release/**` branches with isolated CloudFormation stacks per branch
- All branches share a single ECR repository with unique SHA-based tags
- New `cleanup-release` workflow to tear down stacks after merge
- Widened IAM policy to allow CloudFormation access for release stacks

### Tests
- 28 unit tests for SSRF protection
- Screenshot service unit tests
- Extended smoke tests with SSRF cases
- Extended PDF service and integration tests

### Other
- Bumped version to 1.1.0
- Dependency updates (basic-ftp, vite)
- Fixed GitHub code scanning alert #5 (workflow permissions)

## Test plan
- [ ] Run smoke tests locally (`scripts/smoke-test.sh`)
- [ ] Test PDF generation with HTML and URL
- [ ] Test screenshot endpoint with HTML and URL
- [ ] Verify SSRF protection (private IPs and metadata endpoints are blocked)
- [ ] Test release deployment on AWS
- [ ] Test cleanup workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)