### PR TITLE
Fix deploy: make Lambda reserved concurrency opt-in

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -27,8 +27,19 @@ Parameters:
 
   ReservedConcurrency:
     Type: Number
-    Default: 10
-    Description: Max concurrent Lambda executions — caps cost/DoS blast radius
+    Default: 0
+    Description: >-
+      Max concurrent Lambda executions (caps cost/DoS blast radius). 0 leaves it
+      unset — required when the account's concurrency limit has no headroom to
+      reserve (reserving would drop unreserved below AWS's minimum). Set a
+      positive value only on accounts with raised limits.
+
+# ── Conditions ────────────────────────────────────────────────────────────────
+
+Conditions:
+  # Only apply a reservation when explicitly requested; otherwise omit the
+  # property so deploys succeed on accounts without concurrency headroom.
+  SetReservedConcurrency: !Not [!Equals [!Ref ReservedConcurrency, 0]]
 
 # ── Globals ───────────────────────────────────────────────────────────────────
 
@@ -57,7 +68,7 @@ Resources:
       Dockerfile: Dockerfile
     Properties:
       PackageType: Image
-      ReservedConcurrentExecutions: !Ref ReservedConcurrency
+      ReservedConcurrentExecutions: !If [SetReservedConcurrency, !Ref ReservedConcurrency, !Ref 'AWS::NoValue']
       Policies:
         - S3CrudPolicy:
             BucketName: !Ref S3BucketName


### PR DESCRIPTION
The #29 merge set `ReservedConcurrentExecutions: 10`, but the deploy AWS account has a **total** concurrency limit of 10, so reserving any amount drops unreserved below AWS's minimum → CloudFormation rolled back (`UPDATE_ROLLBACK_COMPLETE`, no downtime).

Fix: default `ReservedConcurrency` to `0` and gate `ReservedConcurrentExecutions` behind a `SetReservedConcurrency` condition, so the property is omitted unless a positive value is explicitly passed (on an account with raised limits).

- No app/code change; `typecheck`/`lint`/`test`/`docker build` unaffected.
- After merge, the Deploy workflow re-runs and applies the rest of #29 (NODE_ENV=production, new image) without the reservation.