### PR TITLE
Fix smoke test: /health is public (200, not 401)

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -48,18 +48,21 @@
           <h1>All current folio endpoints in one place.</h1>
           <p>
             When <code>API_KEY</code> is set, every route requires the
-            <code>X-Api-Key</code> header, including <code>/health</code> and
-            <code>/metrics</code>.
+            <code>X-Api-Key</code> header except <code>GET /health</code>, which
+            is always public so load balancers can probe it. <code>/metrics</code>
+            still requires the key.
           </p>
         </section>
 
         <section id="auth" class="endpoint-card">
           <h2>Authentication</h2>
           <p>
-            All routes are protected by a static API key when the
-            <code>API_KEY</code> environment variable is set. Clients must send the key in
-            the <code>X-Api-Key</code> request header. When <code>API_KEY</code> is unset,
-            auth is skipped for local development.
+            All routes except <code>GET /health</code> are protected by a static API key
+            when the <code>API_KEY</code> environment variable is set;
+            <code>/health</code> is always public for load-balancer probes. Clients must
+            send the key in the <code>X-Api-Key</code> request header. When
+            <code>API_KEY</code> is unset, auth is skipped for local development, but it is
+            required when <code>NODE_ENV=production</code>.
           </p>
           <div class="code-panel">
             <pre><code>curl -X POST http://localhost:8080/pdf/generate \

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -98,9 +98,9 @@ echo ""
 # ── Auth: 401 when API_KEY is configured and header is missing ────────────────
 
 if [ -n "${API_KEY:-}" ]; then
-  echo "--- Auth: missing x-api-key on GET /health → 401 ---"
+  echo "--- Auth: GET /health is public (no key) → 200 ---"
   HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/health")
-  assert_eq "HTTP 401 (health, no key)" "401" "$HTTP_CODE"
+  assert_eq "HTTP 200 (health, no key — public for load balancers)" "200" "$HTTP_CODE"
 
   echo "--- Auth: missing x-api-key on GET /metrics → 401 ---"
   HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/metrics")


### PR DESCRIPTION
Post-deploy smoke test failed:
```
--- Auth: missing x-api-key on GET /health → 401 ---
✗ HTTP 401 (health, no key) (expected: 401, got: 200)
```
This is the smoke test asserting **old** behavior. #29 intentionally made `GET /health` public (so load balancers / orchestrators can probe it without the API key); the protected-route auth check now lives on `/metrics` (still 401 without a key, kept).

Fix: assert `/health` returns **200** without a key. No app change — matches the shipped behavior and the README/AGENTS docs. Verified with `bash -n`.