### PR TITLE
Test coverage follow-ups (concurrency, gs stderr/timeout, auth edge cases, storage errors)

### DIFF
--- a/src/plugins/auth.test.ts
+++ b/src/plugins/auth.test.ts
@@ -49,6 +49,26 @@ describe('authPlugin', () => {
       expect(response.statusCode).toBe(200);
       expect(response.json()).toEqual({ ok: true });
     });
+
+    it('returns 401 for an empty x-api-key header', async () => {
+      const response = await app.inject({
+        method: 'GET',
+        url: '/test',
+        headers: { 'x-api-key': '' },
+      });
+      expect(response.statusCode).toBe(401);
+    });
+
+    it('returns 401 for a wrong key of the same length (timing-safe compare path)', async () => {
+      // Same length as the real key, so the length guard passes and
+      // timingSafeEqual itself must reject the content.
+      const response = await app.inject({
+        method: 'GET',
+        url: '/test',
+        headers: { 'x-api-key': 'x'.repeat(TEST_API_KEY.length) },
+      });
+      expect(response.statusCode).toBe(401);
+    });
   });
 
   describe('when API_KEY is not set', () => {

--- a/src/services/pdf/PdfOperationsService.test.ts
+++ b/src/services/pdf/PdfOperationsService.test.ts
@@ -143,6 +143,41 @@ describe('PdfOperationsService', () => {
       await service.compress(source);
       expect(spawn).toHaveBeenCalledWith('/usr/bin/gs', expect.arrayContaining(['-dSAFER']));
     });
+
+    it('surfaces captured stderr in the failure error', async () => {
+      const proc = new EventEmitter() as MockGsProcess;
+      proc.stderr = new EventEmitter();
+      setImmediate(() => {
+        proc.stderr.emit('data', Buffer.from('GS fatal: cannot process PDF'));
+        proc.emit('close', 1);
+      });
+      vi.mocked(spawn).mockReturnValue(asSpawnReturn(proc));
+      const source = await makePdf(1);
+
+      await expect(service.compress(source)).rejects.toThrow('GS fatal: cannot process PDF');
+    });
+
+    it('kills Ghostscript and rejects when it exceeds the timeout', async () => {
+      const source = await makePdf(1);
+      vi.useFakeTimers();
+      try {
+        const proc = Object.assign(new EventEmitter(), {
+          stderr: new EventEmitter(),
+          kill: vi.fn(),
+        }) as unknown as MockGsProcess & { kill: ReturnType<typeof vi.fn> };
+        // never emits 'close' → the timeout must fire
+        vi.mocked(spawn).mockReturnValue(asSpawnReturn(proc));
+
+        const result = service.compress(source);
+        const rejection = expect(result).rejects.toThrow('timed out');
+        await vi.advanceTimersByTimeAsync(30_000);
+        await rejection;
+
+        expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('convertToPdfA', () => {

--- a/src/services/pdf/PdfService.test.ts
+++ b/src/services/pdf/PdfService.test.ts
@@ -190,6 +190,18 @@ describe('PdfService', () => {
     expect(mockLaunch).toHaveBeenCalledTimes(2);
   });
 
+  it('launches the browser only once under concurrent getBrowser calls', async () => {
+    const [b1, b2, b3] = await Promise.all([
+      pdfService.getBrowser(),
+      pdfService.getBrowser(),
+      pdfService.getBrowser(),
+    ]);
+
+    expect(mockLaunch).toHaveBeenCalledOnce();
+    expect(b1).toBe(b2);
+    expect(b2).toBe(b3);
+  });
+
   describe('SSRF request interception', () => {
     it('enables request interception and registers a guard by default', async () => {
       await pdfService.generate({ html: '<html></html>' });

--- a/src/services/storage/StorageService.test.ts
+++ b/src/services/storage/StorageService.test.ts
@@ -76,4 +76,41 @@ describe('StorageService', () => {
       'PDF not found',
     );
   });
+
+  it('propagates non-404 S3 errors from getUrl instead of masking them as not-found', async () => {
+    const accessDenied = Object.assign(new Error('denied'), { name: 'AccessDenied' });
+    vi.mocked(mockS3Client.send).mockRejectedValueOnce(accessDenied);
+
+    await expect(storageService.getUrl('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')).rejects.toThrow('denied');
+  });
+
+  it('uploads an image and returns a presigned URL', async () => {
+    const stored = await storageService.uploadImage(Buffer.from('PNG'), 'png', 'image/png');
+
+    expect(stored).toMatchObject({ id: expect.any(String), url: expect.stringContaining('https://') });
+    expect(mockS3Client.send).toHaveBeenCalledOnce();
+  });
+
+  it('propagates S3 errors when uploadImage fails', async () => {
+    vi.mocked(mockS3Client.send).mockRejectedValueOnce(new Error('S3 upload failed'));
+
+    await expect(
+      storageService.uploadImage(Buffer.from('PNG'), 'png', 'image/png'),
+    ).rejects.toThrow('S3 upload failed');
+  });
+
+  it('propagates S3 errors when upload fails', async () => {
+    vi.mocked(mockS3Client.send).mockRejectedValueOnce(new Error('PutObject failed'));
+
+    await expect(storageService.upload(Buffer.from('%PDF-1.4'))).rejects.toThrow('PutObject failed');
+  });
+
+  it('throws not found when downloading a missing object', async () => {
+    const noSuchKey = Object.assign(new Error('no key'), { name: 'NoSuchKey' });
+    vi.mocked(mockS3Client.send).mockRejectedValueOnce(noSuchKey);
+
+    await expect(storageService.download('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11')).rejects.toThrow(
+      'PDF not found',
+    );
+  });
 });

--- a/test/integration/metrics.test.ts
+++ b/test/integration/metrics.test.ts
@@ -107,4 +107,23 @@ describe('GET /metrics', () => {
     expect(body).toContain('pdf_generation_duration_ms_count 0');
     expect(body).toContain('pdf_size_bytes_count 0');
   });
+
+  it('records every request under concurrent generation', async () => {
+    const N = 5;
+    await Promise.all(
+      Array.from({ length: N }, () =>
+        app.inject({
+          method: 'POST',
+          url: '/pdf/generate',
+          payload: { html: '<html><body>concurrent</body></html>' },
+        }),
+      ),
+    );
+
+    const response = await app.inject({ method: 'GET', url: '/metrics' });
+    const body = response.body;
+
+    expect(body).toContain(`pdf_generation_requests_total{status="success"} ${N}`);
+    expect(body).toContain(`pdf_generation_duration_ms_count ${N}`);
+  });
 });


### PR DESCRIPTION
Closes the remaining **test-coverage** items from #28 (the non-test deferrals — base-image digest pinning, SAM access logging, puppeteer/chromium compat — stay open there).

Adds 11 tests (168 → **179**), no production code changes:

- **Concurrency:** `PdfService.getBrowser()` launches Chromium once under parallel calls (the lazy-init race); `/metrics` counts every request under N concurrent `/pdf/generate`.
- **Ghostscript:** captured `stderr` is surfaced in the failure error; the 30s timeout kills the process and rejects (fake timers, asserts `SIGKILL`).
- **Auth:** empty-string key and a *same-length* wrong key both → 401 — the latter exercises `timingSafeEqual` itself, not just the length short-circuit.
- **StorageService:** `uploadImage` success + error, `upload` error, `download` 404, and non-404 `getUrl` errors propagate (not masked as not-found).

`typecheck` ✓ · `lint` ✓ · `vitest` **179 passed** ✓.