### PR TITLE
Observability (X-Ray + opt-in access logs) and hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,6 +277,8 @@ Converts an existing PDF to PDF/A using Ghostscript. **Route is only registered 
 
 8. **Ghostscript gating**: `POST /pdf/compress` always exists (pdf-lib fallback), while `POST /pdf/pdfa` is only registered when `GHOSTSCRIPT_PATH` is set (`opsService.canUseGhostscript`). Ghostscript operations write to unique temp files in `os.tmpdir()` and clean up via `Promise.allSettled` in a `finally` block — even if Ghostscript fails.
 
+9. **Deploy-safe IaC defaults**: template features that need account capacity or extra deploy-role permissions are gated behind CloudFormation `Conditions` and default **off**, so the standard deploy never fails on a missing capability. `ReservedConcurrency` (default `0`) is omitted via `AWS::NoValue` unless set; access logging (`EnableAccessLogs`, default `false`) only creates its CloudWatch log group when enabled — and the `github-actions-deploy` role gains `logs:` permissions only after `aws-setup.sh` is re-run. X-Ray (`Tracing: Active`) is on by default because it needs no extra deploy-role perms. Validate template changes with `sam validate --lint` before merging.
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -238,6 +238,12 @@ If deletion fails again, inspect the event log for the specific resource blockin
 | Architecture | x86_64 |
 | Package type | Image |
 
+**Observability**
+
+- **AWS X-Ray tracing** is enabled on the function (`Tracing: Active`) — no extra setup.
+- **API Gateway access logs** are opt-in via the `EnableAccessLogs` SAM parameter (default `false`). They write to a CloudWatch log group, which the deploy role may create only after you re-run `./scripts/aws-setup.sh` (it grants the needed `logs:` permissions); then deploy with `--parameter-overrides EnableAccessLogs=true`. Left off by default so the standard deploy needs no `logs:` permissions.
+- `ReservedConcurrency` (default `0` = unset) caps concurrent executions on accounts with raised limits.
+
 ### Docker / ECS / Fly.io / Railway
 
 Build the image and run anywhere Docker is supported:

--- a/scripts/aws-setup.sh
+++ b/scripts/aws-setup.sh
@@ -278,6 +278,25 @@ JSON
       "Effect": "Allow",
       "Action": "apigateway:*",
       "Resource": "arn:aws:apigateway:${REGION}::/*"
+    },
+    {
+      "Sid": "AccessLogGroup",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:DeleteLogGroup",
+        "logs:PutRetentionPolicy",
+        "logs:TagResource",
+        "logs:UntagResource",
+        "logs:ListTagsForResource"
+      ],
+      "Resource": "arn:aws:logs:${REGION}:${AWS_ACCOUNT_ID}:log-group:/aws/vendedlogs/http-api/folio*"
+    },
+    {
+      "Sid": "DescribeLogGroups",
+      "Effect": "Allow",
+      "Action": "logs:DescribeLogGroups",
+      "Resource": "*"
     }
   ]
 }

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -3,8 +3,14 @@ import { z } from 'zod';
 const envSchema = z
   .object({
     NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
-    S3_BUCKET: z.string().min(1),
-    AWS_REGION: z.string().min(1),
+    S3_BUCKET: z
+      .string()
+      .min(3)
+      .max(63)
+      .regex(/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/, 'Invalid S3 bucket name'),
+    AWS_REGION: z
+      .string()
+      .regex(/^[a-z]{2}-[a-z-]+-\d+$/, 'Invalid AWS region (e.g. eu-central-1)'),
     AWS_ACCESS_KEY_ID: z.string().optional(),
     AWS_SECRET_ACCESS_KEY: z.string().optional(),
     AWS_ENDPOINT_URL: z.url().optional(),

--- a/src/lambda.ts
+++ b/src/lambda.ts
@@ -1,20 +1,37 @@
 import awsLambdaFastify from '@fastify/aws-lambda';
 import { buildApp } from './server.js';
 
-// buildApp() is called at module level (outside the handler) so the browser
-// is launched once and reused across warm invocations.
-const proxyPromise = buildApp().then((app) =>
-  awsLambdaFastify(app, { binaryMimeTypes: ['application/pdf'] }),
-);
+function buildProxy() {
+  return buildApp().then((app) => awsLambdaFastify(app, { binaryMimeTypes: ['application/pdf'] }));
+}
 
-// Derive the handler's parameter types from the proxy itself instead of casting
-// `unknown`, so event/context stay type-checked against @fastify/aws-lambda.
-type Proxy = Awaited<typeof proxyPromise>;
+type ProxyPromise = ReturnType<typeof buildProxy>;
+type Proxy = Awaited<ProxyPromise>;
+
+// Cache the built proxy for warm-invocation reuse (browser stays alive), but
+// reset the cache if init fails so a transient buildApp() failure does not wedge
+// the instance permanently — the next invocation retries instead of awaiting a
+// forever-rejected promise.
+let proxyPromise: ProxyPromise | null = null;
+
+function getProxy(): ProxyPromise {
+  if (proxyPromise === null) {
+    proxyPromise = buildProxy().catch((err: unknown) => {
+      proxyPromise = null;
+      throw err;
+    });
+  }
+  return proxyPromise;
+}
+
+// Eagerly start init at module load for warm-start browser reuse. Swallow the
+// rejection here (the handler retries via getProxy) to avoid an unhandled rejection.
+void getProxy().catch(() => {});
 
 export const handler = async (
   event: Parameters<Proxy>[0],
   context: Parameters<Proxy>[1],
 ) => {
-  const proxy = await proxyPromise;
+  const proxy = await getProxy();
   return proxy(event, context);
 };

--- a/template.yaml
+++ b/template.yaml
@@ -34,12 +34,24 @@ Parameters:
       reserve (reserving would drop unreserved below AWS's minimum). Set a
       positive value only on accounts with raised limits.
 
+  EnableAccessLogs:
+    Type: String
+    Default: "false"
+    AllowedValues: ["true", "false"]
+    Description: >-
+      Enable API Gateway access logging to CloudWatch. Default "false" so the
+      deploy needs no logs: permissions. To enable: re-run scripts/aws-setup.sh
+      (grants the deploy role logs: perms) THEN deploy with EnableAccessLogs=true.
+
 # ── Conditions ────────────────────────────────────────────────────────────────
 
 Conditions:
   # Only apply a reservation when explicitly requested; otherwise omit the
   # property so deploys succeed on accounts without concurrency headroom.
   SetReservedConcurrency: !Not [!Equals [!Ref ReservedConcurrency, 0]]
+  # Access logging is opt-in: the log group (and thus logs: permissions) only
+  # materialises when explicitly enabled, so the default deploy stays green.
+  AccessLogsEnabled: !Equals [!Ref EnableAccessLogs, "true"]
 
 # ── Globals ───────────────────────────────────────────────────────────────────
 
@@ -48,6 +60,7 @@ Globals:
     MemorySize: 2048
     Timeout: 120
     Architectures: [x86_64]
+    Tracing: Active  # AWS X-Ray for the Lambda (deploy-safe: uses lambda:* + iam on folio*)
     Environment:
       Variables:
         NODE_ENV:                   production
@@ -84,6 +97,28 @@ Resources:
           Properties:
             Path: /
             Method: ANY
+
+  # Declaring the implicit API explicitly under its conventional logical id lets
+  # us attach access logging without changing the API or its URL. When disabled,
+  # AccessLogSettings is omitted, so it behaves exactly like the implicit API.
+  ServerlessHttpApi:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      StageName: "$default"
+      AccessLogSettings: !If
+        - AccessLogsEnabled
+        - DestinationArn: !GetAtt AccessLogGroup.Arn
+          Format: '{"requestId":"$context.requestId","ip":"$context.http.sourceIp","method":"$context.http.method","path":"$context.http.path","status":"$context.status","latencyMs":"$context.responseLatency","integrationError":"$context.integrationErrorMessage"}'
+        - !Ref "AWS::NoValue"
+
+  # Created only when access logging is enabled, so the default deploy needs no
+  # logs: permissions on the deploy role.
+  AccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Condition: AccessLogsEnabled
+    Properties:
+      LogGroupName: !Sub "/aws/vendedlogs/http-api/${AWS::StackName}"
+      RetentionInDays: 30
 
 # ── Outputs ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Tackles the remaining #28 items that are safe to do here, in one branch.

## What's included
**Observability (SAM)**
- **X-Ray tracing** on the Lambda (`Tracing: Active`) — deploy-safe (needs only `lambda:*` + `iam:AttachRolePolicy` on `folio*`, which the deploy role has). Active immediately.
- **API Gateway access logging — opt-in** via the `EnableAccessLogs` parameter (default `false`). When off, the template behaves exactly like today (no log group, no `logs:` perms needed → deploy stays green). When on, it adds a conditional CloudWatch log group + `AccessLogSettings` on an explicit `ServerlessHttpApi` declared under the **same logical id**, so the API and its URL don't change.
  - To enable: re-run `./scripts/aws-setup.sh` (now grants the deploy role scoped `logs:` perms), then `sam deploy --parameter-overrides EnableAccessLogs=true`.

**Hardening**
- `lambda.ts`: guard `buildApp()` rejection — the cached proxy promise resets on failure, so a transient init error retries on the next invocation instead of wedging the warm instance with a forever-rejected promise.
- `env.ts`: tighten `S3_BUCKET` (S3 naming rules) and `AWS_REGION` (region regex that still accepts gov/iso regions) validation.

## Verification
- `sam validate --lint` → **valid SAM Template**, no findings.
- `typecheck` ✓ · `lint` ✓ · `vitest` **179 passed** ✓ · `build` ✓.
- Default `EnableAccessLogs=false` → no new IAM/logs requirements; the standard deploy is unaffected (the explicit `ServerlessHttpApi` reuses the implicit logical id, so it's an update, not a replacement).

## Not included (intentional)
- **Base-image digest pinning** — can't resolve real digests in this environment (no docker/registry access); fabricating a digest would break the build. Stays open in #28 for a maintainer/CI resolve step.

## Note on the access-log path
The default (off) path is unchanged and safe. The `EnableAccessLogs=true` path was validated structurally (`sam validate --lint`) but not deploy-tested; recommend reviewing the changeset (`sam deploy --no-execute-changeset`) the first time you enable it.