### PR TITLE
Pin base-image digests + harden aws-setup.sh error reporting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Stage 1: build
-FROM node:24-slim AS builder
+# Pinned by digest for reproducibility (node:24-slim, linux/amd64 — folio builds
+# x86_64 only). Update the digest with: docker manifest inspect node:24-slim
+FROM node:24-slim@sha256:cbd8bcbdfd0d148205c9449dff3ca3c9c94d73f393a0e03ef1c8d3846c5038bf AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -8,7 +10,9 @@ COPY src/ src/
 RUN npm run build
 
 # Stage 2: production image used by local Docker, Lambda deploys, and GHCR
-FROM public.ecr.aws/lambda/nodejs:24 AS server
+# Pinned by digest (public.ecr.aws/lambda/nodejs:24, linux/amd64 — Lambda runs
+# x86_64). Update with: docker manifest inspect public.ecr.aws/lambda/nodejs:24
+FROM public.ecr.aws/lambda/nodejs:24@sha256:0ef0587366631c01cda7646c4dbd0509f622fecc56ccbed63c8dca65c26b5b2b AS server
 WORKDIR /var/task
 RUN dnf install -y \
       alsa-lib \

--- a/scripts/aws-setup.sh
+++ b/scripts/aws-setup.sh
@@ -25,6 +25,11 @@ success() { printf '%s✓%s  %s\n'    "$green"  "$reset" "$*"; }
 warn()    { printf '%s!%s  %s\n'    "$yellow" "$reset" "$*"; }
 die()     { printf '%s✗%s  %s\n'    "$red"    "$reset" "$*" >&2; exit 1; }
 
+# Report the failing step on any error. No destructive rollback: every step is
+# idempotent (it checks for existing resources before creating), so the script
+# is safe to re-run after fixing the cause.
+trap 'rc=$?; [ "$rc" -ne 0 ] && printf "%s✗%s  Setup failed at line %s (exit %s). Already-created resources are kept; fix the cause and re-run — all steps are idempotent.\n" "$red" "$reset" "$LINENO" "$rc" >&2' ERR
+
 # Wrapper — injects --profile on every aws call once AWS_PROFILE is set.
 # Falls back to the ambient credentials for check_prereqs (aws --version).
 aws() {


### PR DESCRIPTION
Closes the last two open items in #28.

## Base-image digest pinning
Both registry base images are now pinned by digest for reproducible builds (resolved via `docker manifest inspect`, linux/amd64 — folio builds x86_64 only):
- `node:24-slim@sha256:cbd8…38bf` (builder)
- `public.ecr.aws/lambda/nodejs:24@sha256:0ef0…5b2b` (production)

Each `FROM` has a comment with the refresh command for future Node bumps.

## aws-setup.sh error handling
Added an `ERR` trap that reports the failing line + exit code and notes that re-running is safe (every step is idempotent). Deliberately **no** destructive rollback — for a bootstrap script you want to keep created resources and re-run, not delete them.

## Verification
- `typecheck` / `lint` ✓; `bash -n scripts/aws-setup.sh` ✓.
- The pinned digests are validated by CI's **Docker Build Check** (pulls the digests + builds) — not reproducible locally (no Docker in the authoring env).