### PR TITLE
Grant deploy role perms for stack delete + access-log delivery

### DIFF
--- a/scripts/aws-setup.sh
+++ b/scripts/aws-setup.sh
@@ -265,7 +265,8 @@ JSON
       "Action": [
         "iam:CreateRole", "iam:DeleteRole", "iam:GetRole", "iam:TagRole",
         "iam:AttachRolePolicy", "iam:DetachRolePolicy",
-        "iam:PutRolePolicy", "iam:DeleteRolePolicy", "iam:GetRolePolicy"
+        "iam:PutRolePolicy", "iam:DeleteRolePolicy", "iam:GetRolePolicy",
+        "iam:ListRolePolicies", "iam:ListAttachedRolePolicies"
       ],
       "Resource": "arn:aws:iam::${AWS_ACCOUNT_ID}:role/folio*"
     },
@@ -301,6 +302,20 @@ JSON
       "Sid": "DescribeLogGroups",
       "Effect": "Allow",
       "Action": "logs:DescribeLogGroups",
+      "Resource": "*"
+    },
+    {
+      "Sid": "AccessLogDelivery",
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogDelivery",
+        "logs:GetLogDelivery",
+        "logs:UpdateLogDelivery",
+        "logs:DeleteLogDelivery",
+        "logs:ListLogDeliveries",
+        "logs:PutResourcePolicy",
+        "logs:DescribeResourcePolicies"
+      ],
       "Resource": "*"
     }
   ]


### PR DESCRIPTION
An IAM audit (AWS-doc-verified) found the `github-actions-deploy` role is fully sufficient for the **default deploy** (confirmed by 6+ green deploys) but missing permissions on two paths it never exercised:

## Gap 1 — Stack DELETE (`cleanup-release.yml`)
CloudFormation must enumerate the Lambda execution role's attached managed policies (`AWSLambdaBasicExecutionRole`, `AWSXRayDaemonWriteAccess`) and inline policy before detaching/deleting them. Missing `iam:ListAttachedRolePolicies` + `iam:ListRolePolicies` → `delete-stack` fails with **DELETE_FAILED** (matches the existing README troubleshooting note). **Fix:** add both (scoped to `role/folio*`).

## Gap 2 — Access logging (`EnableAccessLogs=true`, the #35 opt-in path)
API Gateway v2 HTTP API access logging uses CloudWatch Logs *log delivery*, which per [AWS docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-logging.html) needs `logs:{Create,Get,Update,Delete}LogDelivery`, `logs:ListLogDeliveries`, `logs:PutResourcePolicy`, `logs:DescribeResourcePolicies` — **not** covered by `apigateway:*` (different service namespace). Without them, enabling access logs fails. **Fix:** add them on `Resource: "*"` (these actions don't support resource-level scoping).

## Notes
- **Additive only** — no change to the default deploy; takes effect when `aws-setup.sh` is re-run.
- 5 other candidate gaps (e.g. `iam:UpdateRole`/`UntagRole`, log-stream read actions) were **adversarially refuted** as not required / covered by wildcards, and deliberately not added (least privilege).
- Verified: `bash -n scripts/aws-setup.sh` ✓ (script isn't run in CI; no app code changed).