### PR TITLE
Document /screenshot in the API reference + smoke-test coverage

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -38,6 +38,7 @@
             <a href="#split"><span class="method method-post">POST</span> /pdf/split</a>
             <a href="#compress"><span class="method method-post">POST</span> /pdf/compress</a>
             <a href="#pdfa"><span class="method method-post">POST</span> /pdf/pdfa</a>
+            <a href="#screenshot"><span class="method method-post">POST</span> /screenshot</a>
           </nav>
         </div>
       </aside>
@@ -520,6 +521,74 @@
               <pre><code>curl -s -X POST http://localhost:8080/pdf/pdfa \
   -H "Content-Type: application/json" \
   -d '{"id": "PDF_ID", "conformance": "2b"}' | jq .</code></pre>
+            </div>
+          </div>
+        </section>
+
+        <section id="screenshot" class="endpoint-card">
+          <div class="endpoint-heading">
+            <span class="method method-post">POST</span>
+            <code>/screenshot</code>
+          </div>
+          <p>
+            Render raw HTML or a URL to an image (PNG, JPEG, or WebP). Provide
+            <code>html</code> <strong>or</strong> <code>url</code> — the two fields
+            are mutually exclusive.
+          </p>
+
+          <h3>Request body</h3>
+          <div class="code-panel">
+            <pre><code>{
+  "html": "&lt;html&gt;&lt;body&gt;&lt;h1&gt;Hello&lt;/h1&gt;&lt;/body&gt;&lt;/html&gt;",
+  "css": "body { font-family: Arial, sans-serif; }",
+  "viewport": { "width": 1280, "height": 720 },
+  "format": "png",
+  "quality": 80,
+  "fullPage": false,
+  "clip": { "x": 0, "y": 0, "width": 400, "height": 300 },
+  "stream": false
+}</code></pre>
+          </div>
+
+          <table>
+            <thead>
+              <tr>
+                <th>Field</th>
+                <th>Type</th>
+                <th>Required</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr><td><code>html</code></td><td>string</td><td>html or url</td><td>HTML to render (mutually exclusive with <code>url</code>)</td></tr>
+              <tr><td><code>url</code></td><td>string (URL)</td><td>html or url</td><td>URL to render; subject to the server SSRF policy</td></tr>
+              <tr><td><code>css</code></td><td>string</td><td>no</td><td>Extra CSS injected before capture</td></tr>
+              <tr><td><code>viewport</code></td><td><code>{ width, height }</code></td><td>no</td><td>Viewport in px (default 1280×720, max 3840×2160)</td></tr>
+              <tr><td><code>format</code></td><td><code>png</code> | <code>jpeg</code> | <code>webp</code></td><td>no</td><td>Image format, default <code>png</code></td></tr>
+              <tr><td><code>quality</code></td><td>number</td><td>no</td><td>1–100; ignored for <code>png</code></td></tr>
+              <tr><td><code>fullPage</code></td><td>boolean</td><td>no</td><td>Capture the full scrollable page, default <code>false</code></td></tr>
+              <tr><td><code>clip</code></td><td><code>{ x, y, width, height }</code></td><td>no</td><td>Capture only a sub-region</td></tr>
+              <tr><td><code>stream</code></td><td>boolean</td><td>no</td><td><code>true</code> returns binary, <code>false</code> returns a stored image URL</td></tr>
+            </tbody>
+          </table>
+
+          <h3>Response when <code>stream: false</code></h3>
+          <div class="code-panel">
+            <pre><code>{ "statusCode": 200, "data": { "url": "https://s3.amazonaws.com/...?X-Amz-Signature=..." } }</code></pre>
+          </div>
+
+          <h3>Response when <code>stream: true</code></h3>
+          <ul class="compact-list">
+            <li><code>Content-Type: image/png</code> (or <code>image/jpeg</code>, <code>image/webp</code>)</li>
+            <li><code>Content-Disposition: attachment; filename="screenshot.png"</code></li>
+          </ul>
+
+          <div class="example-block">
+            <span class="example-label">Example</span>
+            <div class="code-panel">
+              <pre><code>curl -s -X POST http://localhost:8080/screenshot \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://example.com", "format": "png"}' | jq .</code></pre>
             </div>
           </div>
         </section>

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -334,6 +334,51 @@ else
   echo ""
 fi
 
+# ── POST /screenshot → S3 URL ─────────────────────────────────────────────────
+
+echo "--- POST /screenshot (stream: false) ---"
+RESP=$(curl -s -X POST "$BASE/screenshot" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"html": "<html><body><h1>Smoke Shot</h1></body></html>", "format": "png"}')
+STATUS_CODE=$(echo "$RESP" | grep -o '"statusCode":[0-9]*' | grep -o '[0-9]*')
+assert_eq "statusCode 200" "200" "$STATUS_CODE"
+assert_contains "screenshot response contains url" '"url"' "$RESP"
+
+echo ""
+
+# ── POST /screenshot → binary stream ─────────────────────────────────────────
+
+echo "--- POST /screenshot (stream: true) ---"
+TMP_PNG=$(mktemp /tmp/smoke-test-shot-XXXXXX.png)
+HTTP_CODE=$(curl -s -X POST "$BASE/screenshot" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"html": "<html><body><h1>Smoke Shot</h1></body></html>", "format": "png", "stream": true}' \
+  -o "$TMP_PNG" -w "%{http_code}")
+assert_eq "HTTP 200" "200" "$HTTP_CODE"
+
+# PNG signature is the bytes \x89 P N G — check for "PNG" in the first 8 bytes.
+if head -c 8 "$TMP_PNG" 2>/dev/null | grep -q "PNG"; then
+  ok "screenshot response is a valid PNG"
+else
+  fail "screenshot response is not a valid PNG"
+fi
+rm -f "$TMP_PNG"
+
+echo ""
+
+# ── POST /screenshot validation: invalid format → 400 ────────────────────────
+
+echo "--- POST /screenshot (invalid format → 400) ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST "$BASE/screenshot" \
+  "${AUTH_HEADER[@]+"${AUTH_HEADER[@]}"}"  \
+  -H "Content-Type: application/json" \
+  -d '{"html": "<h1>x</h1>", "format": "gif"}')
+assert_eq "HTTP 400 (bad format)" "400" "$HTTP_CODE"
+
+echo ""
+
 # ── POST /pdf/generate with url field ────────────────────────────────────────
 
 echo "--- POST /pdf/generate (url, stream: false) ---"


### PR DESCRIPTION
Closes the loose end: `POST /screenshot` is supported by the server and the client, but was missing from the public API reference and the smoke test.

## Changes
- **docs/api/index.html**: new `/screenshot` endpoint card (matching the other endpoints — request body, field table, `stream:false`/`stream:true` responses, curl example) + a side-nav entry. Republished via the Pages workflow on merge.
- **scripts/smoke-test.sh**: add `/screenshot` checks — stored-URL response (`stream:false`), binary PNG stream verified by the PNG signature (`stream:true`), and a `400` for an invalid `format`. Previously the smoke test had **zero** screenshot coverage.

## Verification
- `bash -n scripts/smoke-test.sh` ✓; HTML `<section>` tags balanced (13/13), nav + section present.
- The smoke test runs against the live Lambda in the deploy pipeline, so the new screenshot assertions are exercised on the next deploy (now with Chromium 149).