### PR TITLE
chore: release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## [1.2.0](https://github.com/alegerber/folio/compare/v1.1.0...v1.2.0) (2026-06-03)
+
+
+### Features
+
+* per-route Prometheus metrics (`http_request_duration_ms`, `http_requests_total`) covering every endpoint
+* rate limiting via `@fastify/rate-limit`
+* AWS X-Ray tracing and opt-in API Gateway access logging (`EnableAccessLogs`)
+* graceful shutdown (SIGTERM/SIGINT) so container stops close the browser cleanly
+
+
+### Bug Fixes
+
+* **security:** filter every Chromium request — sub-resources and redirects, not just the top-level URL — and use ipaddr.js for robust private-IP detection (IPv4-mapped IPv6, fd00::/8, 0.0.0.0)
+* **security:** mask 5xx error responses so internals (e.g. Ghostscript stderr) are not leaked
+* **security:** make `/health` public for load-balancer probes; require `API_KEY` when `NODE_ENV=production`; run Ghostscript with `-dSAFER`
+* add timeouts to `page.setContent` and the Ghostscript subprocess; recover from Chromium disconnects
+* enforce request input limits (html/css/cookies sizes) and a `paper.size` enum
+* align `puppeteer-core` 25 with `@sparticuz/chromium` 149 (Chromium 149)
+
+
+### Build System
+
+* pin base-image digests; run CI actions on Node 24; use `npm ci`
+* grant the deploy role permissions for stack deletion and access-log delivery
+
+
 ## [1.1.0](https://github.com/alegerber/folio/compare/v1.0.0...v1.1.0) (2026-04-14)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "folio",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "PDF generation microservice using Puppeteer, Fastify, and S3",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Manual release for folio (server). The security/observability/hardening work in #29–#38 used non-conventional commit messages, so release-please did not auto-version it — this reconciles the version.

- Bump `package.json` 1.1.0 → **1.2.0** (Features + Bug Fixes, **no breaking API changes** → minor).
- Add the `CHANGELOG.md` 1.2.0 entry (release-please format) summarising #29–#38.

After merge, `v1.2.0` will be tagged on main, which triggers `publish.yml` to push `ghcr.io/alegerber/folio:1.2.0`. release-please continues from v1.2.0 for future (conventional) commits.

_(Note: v2.0.0 was intentionally **not** used — the server has no breaking API changes and is at 1.x; folio-client is the one at v2.0.0.)_