### PR TITLE
ci: bump all GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,18 +9,13 @@ on:
 permissions:
   contents: read
 
-env:
-  # Node 20 action runtime is deprecated (GitHub forces Node 24 from 2026-06-16).
-  # Opt in now for actions without a Node 24 release yet (docker/*); remove once they ship one.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -31,8 +26,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -43,8 +38,8 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-node@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '24'
           cache: 'npm'
@@ -55,10 +50,10 @@ jobs:
     name: Docker Build Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: false

--- a/.github/workflows/cleanup-release.yml
+++ b/.github/workflows/cleanup-release.yml
@@ -12,11 +12,6 @@ permissions:
   id-token: write
   contents: read
 
-env:
-  # Node 20 action runtime is deprecated (GitHub forces Node 24 from 2026-06-16).
-  # Opt in now for actions without a Node 24 release yet (aws-actions/*); remove once they ship one.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   cleanup:
     name: Delete Release Stack
@@ -36,7 +31,7 @@ jobs:
           echo "Cleaning up stack=${STACK}"
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-deploy
           aws-region: eu-central-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,11 +8,6 @@ permissions:
   id-token: write
   contents: read
 
-env:
-  # Node 20 action runtime is deprecated (GitHub forces Node 24 from 2026-06-16).
-  # Opt in now for actions without a Node 24 release yet (aws-actions/*); remove once they ship one.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   deploy:
     name: SAM Deploy
@@ -22,7 +17,7 @@ jobs:
       stack-name: ${{ steps.env.outputs.stack-name }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Derive environment
         id: env
@@ -35,10 +30,10 @@ jobs:
             echo "stack-name=folio-${SUFFIX}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: aws-actions/setup-sam@v2
+      - uses: aws-actions/setup-sam@v3
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/github-actions-deploy
           aws-region: eu-central-1
@@ -75,7 +70,7 @@ jobs:
     needs: deploy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Run smoke test
         run: ./scripts/smoke-test.sh "${{ needs.deploy.outputs.api-url }}"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,11 +18,6 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
-env:
-  # Node 20 action runtime is deprecated (GitHub forces Node 24 from 2026-06-16).
-  # Opt in now for actions without a Node 24 release yet (actions/*-pages*); remove once they ship one.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   deploy:
     name: Deploy GitHub Pages
@@ -31,13 +26,14 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: actions/configure-pages@v5
+      - uses: actions/configure-pages@v6
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: docs
+          include-hidden-files: true   # preserve docs/.nojekyll (excluded by default since v4)
 
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,21 +9,16 @@ permissions:
   contents: read
   packages: write
 
-env:
-  # Node 20 action runtime is deprecated (GitHub forces Node 24 from 2026-06-16).
-  # Opt in now for actions without a Node 24 release yet (docker/*); remove once they ship one.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -31,7 +26,7 @@ jobs:
 
       - name: Extract metadata (standard image)
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -41,7 +36,7 @@ jobs:
 
       - name: Extract metadata (full image)
         id: meta-full
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -50,7 +45,7 @@ jobs:
             type=raw,value=latest-full
 
       - name: Build and push standard image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: server
@@ -60,7 +55,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Build and push full image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           target: server-full

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,16 +9,10 @@ permissions:
   contents: write
   pull-requests: write
 
-env:
-  # Node 20 action runtime is deprecated (GitHub forces Node 24 from 2026-06-16).
-  # Opt in now for actions without a Node 24 release yet; remove once they ship one.
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         with:
           release-type: node
-          package-name: folio


### PR DESCRIPTION
Implements #40 — bumps every pinned action to its current major (all node24 runtimes, satisfied by `ubuntu-latest`).

## Changes
- `checkout` v5→v6, `setup-node` v5→v6 (ci.yml, deploy.yml, pages.yml, publish.yml)
- `configure-pages` v5→v6, `upload-pages-artifact` v3→v5, `deploy-pages` v4→v5 (pages.yml)
- `setup-buildx-action` v3→v4, `build-push-action` v6→v7, `login-action` v3→v4, `metadata-action` v5→v6 (ci.yml, publish.yml)
- `configure-aws-credentials` v4→v6, `setup-sam` v2→v3 (deploy.yml, cleanup-release.yml)
- `release-please-action` v4→v5 (release-please.yml)

## Non-mechanical bits
- **`include-hidden-files: true`** on `upload-pages-artifact` — v4+ excludes dotfiles by default; without this the committed `docs/.nojekyll` would stop shipping and Pages could re-enable Jekyll.
- **Removed `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`** from all six workflows — every `docker/*` and `aws-actions/*` action now ships node24 natively, so the temporary hedge is redundant.
- **Removed `package-name: folio`** from release-please — not a recognized input in v4 or v5 (silent no-op).

## Verification
- All 8 workflows parse cleanly (js-yaml); no stale pins, no leftover hedge env.
- This PR's own CI (`ci.yml` on `pull_request`) exercises the new `checkout@v6`/`setup-node@v6`/`setup-buildx-action@v4`/`build-push-action@v7` live, including the Docker build.

Breaking-change notes per action were researched against each action's release notes and `action.yml` (see #40).

Closes #40